### PR TITLE
Use Cypher1's fork of rapidcheck

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ references:
     run:
       name: Install dependencies on Arch
       command: |
-        pacman -Syu --noconfirm base-devel git cmake clang gcc
+        pacman -Syu --noconfirm base-devel git openssh cmake clang gcc
 
   update_submodules: &update_submodules
     run:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib/rapidcheck"]
 	path = src/lib/rapidcheck
-	url = https://github.com/emil-e/rapidcheck.git
+	url = https://github.com/cypher1/rapidcheck.git


### PR DESCRIPTION
This allows us to enable slightly more permissive compile flags and
possibly perform some maintainance.