### PR TITLE
Python style string multiplication

### DIFF
--- a/src/eval.cc
+++ b/src/eval.cc
@@ -9,18 +9,11 @@
 using Prim = std::variant<int, std::string>;
 
 std::string repeat(int n, std::string rep) {
-  if (n<1) {
-    return "";
+  std::string o = rep;
+  while(o.length() < rep.length()*n) {
+    o += o;
   }
-  std::string o = "";
-  if (n%2 == 1) {
-    o += rep;
-  }
-  if (n > 1) {
-    const auto s = repeat(n/2, rep);
-    o += s+s;
-  }
-  return o;
+  return o.substr(0, rep.length()*n);
 }
 
 Prim eval(Value val) {

--- a/src/eval.cc
+++ b/src/eval.cc
@@ -8,6 +8,21 @@
 
 using Prim = std::variant<int, std::string>;
 
+std::string repeat(int n, std::string rep) {
+  if (n<1) {
+    return "";
+  }
+  std::string o = "";
+  if (n%2 == 1) {
+    o += rep;
+  }
+  if (n > 1) {
+    const auto s = repeat(n/2, rep);
+    o += s+s;
+  }
+  return o;
+}
+
 Prim eval(Value val) {
   std::cerr << "Eval (" << show(val) << ")\n";
   // TODO: Eval
@@ -43,6 +58,12 @@ Prim eval(Value val) {
       // Require two args for now?
       if(std::holds_alternative<int>(values[0]) && std::holds_alternative<int>(values[1])) {
         return std::get<int>(values[0])*std::get<int>(values[1]);
+      }
+      if(std::holds_alternative<int>(values[1]) && std::holds_alternative<std::string>(values[0])) {
+        return repeat(std::get<int>(values[1]), std::get<std::string>(values[0]));
+      }
+      if(std::holds_alternative<int>(values[0]) && std::holds_alternative<std::string>(values[1])) {
+        return repeat(std::get<int>(values[0]), std::get<std::string>(values[1]));
       }
       return "Unexpected types at (*) !!! "+val.name;
     } else {

--- a/test/eval_tests.cc
+++ b/test/eval_tests.cc
@@ -126,3 +126,29 @@ TEST_CASE("an expression with string literals") {
     REQUIRE(std::get<std::string>(val) == "abcdef");
   }
 }
+
+TEST_CASE("an expression with string literals") {
+  Messages msgs;
+  Context ctx = {msgs, "'abc' * (2+1)", "<filename>"};
+
+  Value num = getValue(msgs, ctx);
+
+  SUBCASE("eval") {
+    auto val = eval(num);
+    REQUIRE(std::holds_alternative<std::string>(val));
+    REQUIRE(std::get<std::string>(val) == "abcabcabc");
+  }
+}
+
+TEST_CASE("an expression with string literals") {
+  Messages msgs;
+  Context ctx = {msgs, "'abc' + ('def'*(2+1))", "<filename>"};
+
+  Value num = getValue(msgs, ctx);
+
+  SUBCASE("eval") {
+    auto val = eval(num);
+    REQUIRE(std::holds_alternative<std::string>(val));
+    REQUIRE(std::get<std::string>(val) == "abcdefdefdef");
+  }
+}


### PR DESCRIPTION
Should be useful for indentation.
Uses doubling to produce a repeated string as long or longer than needed and then substrings that to get the correct length. This avoids any recursion or complexity needed for the divide and conquer approach.