### PR TITLE
Use TError for err

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -9,18 +9,27 @@ use crate::location::*;
 use crate::tree::*;
 use crate::types::Type;
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash)]
-pub struct Err {
-    pub msg: String,
-    pub info: Info,
-}
-
-impl ToNode for Err {
+impl ToNode for TError {
     fn to_node(self) -> Node {
         Node::Error(self)
     }
     fn get_info(&self) -> Info {
-        self.info.clone()
+        use TError::*;
+        let default = Info::default();
+        match self {
+            CppCompilerError(_, _) => &default,
+            UnknownSymbol(_, info, _) => info,
+            UnknownInfixOperator(_, info) => info,
+            UnknownPrefixOperator(_, info) => info,
+            UnknownSizeOfVariableType(_, info) => info,
+            StaticPointerCardinality(info) => info,
+            TypeMismatch(_, _, info) => info,
+            TypeMismatch2(_, _, _, info) => info,
+            RequirementFailure(info) => info,
+            FailedParse(_, info) => info,
+            InternalError(_, node) => &node.get_info(),
+            ExpectedLetNode(node) => &node.get_info(),
+        }.clone()
     }
 }
 
@@ -242,7 +251,7 @@ impl Hash for Info {
 // #[derive(Debug)]
 #[derive(PartialEq, Eq, Clone, Hash)]
 pub enum Node {
-    Error(Err),
+    Error(TError),
     SymNode(Sym),
     PrimNode(Prim),
     ApplyNode(Apply),

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -15,21 +15,20 @@ impl ToNode for TError {
     }
     fn get_info(&self) -> Info {
         use TError::*;
-        let default = Info::default();
         match self {
-            CppCompilerError(_, _) => &default,
-            UnknownSymbol(_, info, _) => info,
-            UnknownInfixOperator(_, info) => info,
-            UnknownPrefixOperator(_, info) => info,
-            UnknownSizeOfVariableType(_, info) => info,
-            StaticPointerCardinality(info) => info,
-            TypeMismatch(_, _, info) => info,
-            TypeMismatch2(_, _, _, info) => info,
-            RequirementFailure(info) => info,
-            FailedParse(_, info) => info,
-            InternalError(_, node) => &node.get_info(),
-            ExpectedLetNode(node) => &node.get_info(),
-        }.clone()
+            CppCompilerError(_, _) => Info::default(),
+            UnknownSymbol(_, info, _) => info.clone(),
+            UnknownInfixOperator(_, info) => info.clone(),
+            UnknownPrefixOperator(_, info) => info.clone(),
+            UnknownSizeOfVariableType(_, info) => info.clone(),
+            StaticPointerCardinality(info) => info.clone(),
+            TypeMismatch(_, _, info) => info.clone(),
+            TypeMismatch2(_, _, _, info) => info.clone(),
+            RequirementFailure(info) => info.clone(),
+            FailedParse(_, info) => info.clone(),
+            InternalError(_, node) => node.get_info(),
+            ExpectedLetNode(node) => node.get_info(),
+        }
     }
 }
 
@@ -310,7 +309,7 @@ impl Node {
         if let LetNode(n) = self {
             return Ok(n.clone());
         }
-        Err(TError::ExpectedLetNode(self.clone()))
+        Err(TError::ExpectedLetNode(Box::new(self.clone())))
     }
 }
 
@@ -401,7 +400,7 @@ pub trait Visitor<State, Res, Final, Start = Root> {
         &mut self,
         db: &dyn Compiler,
         state: &mut State,
-        e: &Err,
+        e: &TError,
     ) -> Result<Res, TError>;
     fn visit_sym(&mut self, db: &dyn Compiler, state: &mut State, e: &Sym) -> Result<Res, TError>;
     fn visit_prim(&mut self, db: &dyn Compiler, state: &mut State, e: &Prim)

--- a/src/definition_finder.rs
+++ b/src/definition_finder.rs
@@ -150,8 +150,8 @@ impl Visitor<State, Node, Root, Path> for DefinitionFinder {
         .to_node())
     }
 
-    fn handle_error(&mut self, _db: &dyn Compiler, _state: &mut State, expr: &Err) -> Res {
-        Err(TError::FailedParse(expr.msg.to_string(), expr.get_info()))
+    fn handle_error(&mut self, _db: &dyn Compiler, _state: &mut State, expr: &TError) -> Res {
+        Err(expr.clone())
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 
 use derivative::Derivative;
 #[derive(Error, Derivative)]
-#[derivative(Debug, PartialEq, Eq, Clone)]
+#[derivative(Debug, PartialEq, Eq, Clone, Hash)]
 pub enum TError {
     #[error("call to C++ compiler failed with error code: {1:?}\n{0}")]
     CppCompilerError(String, Option<i32>),
@@ -33,8 +33,8 @@ pub enum TError {
     #[error("parse failed, {0} at {1:?}")]
     FailedParse(String, Info),
     #[error("internal error `{0}` at {1}")]
-    InternalError(String, Node),
+    InternalError(String, Box<Node>),
 
     #[error("Expected a let node, got `{0}`")]
-    ExpectedLetNode(Node),
+    ExpectedLetNode(Box<Node>),
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -455,8 +455,8 @@ impl<'a> Visitor<State, Prim, Prim> for Interpreter<'a> {
         }
     }
 
-    fn handle_error(&mut self, _db: &dyn Compiler, _state: &mut State, expr: &Err) -> Res {
-        Err(TError::FailedParse(expr.msg.to_string(), expr.get_info()))
+    fn handle_error(&mut self, _db: &dyn Compiler, _state: &mut State, expr: &TError) -> Res {
+        Err(expr.clone())
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -123,11 +123,7 @@ fn nud(db: &dyn Compiler, mut toks: VecDeque<Token>) -> Result<(Node, VecDeque<T
         }
     } else {
         Ok((
-            Err {
-                msg: "Unexpected eof, expected expr".to_string(),
-                info: Info::default(),
-            }
-            .to_node(),
+            TError::FailedParse("Unexpected eof, expected expr".to_string(), Info::default()).to_node(),
             toks,
         ))
     }
@@ -174,22 +170,14 @@ fn led(
     }) = toks.front()
     {
         return Ok((
-            Err {
-                msg: "Close bracket".to_string(),
-                info: pos.clone().get_info(),
-            }
-            .to_node(),
+            TError::FailedParse("Exected Close bracket".to_string(), pos.clone().get_info()).to_node(),
             toks,
         ));
     }
 
     match toks.pop_front() {
         None => Ok((
-            Err {
-                msg: "Unexpected eof, expected expr tail".to_string(),
-                info: left.get_info(),
-            }
-            .to_node(),
+            TError::FailedParse("Unexpected eof, expected expr tail".to_string(), left.get_info()).to_node(),
             toks,
         )),
         Some(head) => match head.tok_type {

--- a/src/pretty_print.rs
+++ b/src/pretty_print.rs
@@ -111,8 +111,8 @@ impl Visitor<State, (), String, Node> for PrettyPrint {
         Ok(())
     }
 
-    fn handle_error(&mut self, _db: &dyn Compiler, _state: &mut State, expr: &Err) -> Res {
-        Err(TError::FailedParse(expr.msg.to_string(), expr.get_info()))
+    fn handle_error(&mut self, _db: &dyn Compiler, _state: &mut State, expr: &TError) -> Res {
+        Err(expr.clone())
     }
 }
 

--- a/src/symbol_table_builder.rs
+++ b/src/symbol_table_builder.rs
@@ -182,8 +182,8 @@ impl Visitor<State, Node, Root, Path> for SymbolTableBuilder {
         .to_node())
     }
 
-    fn handle_error(&mut self, _db: &dyn Compiler, _state: &mut State, expr: &Err) -> Res {
-        Err(TError::FailedParse(expr.msg.to_string(), expr.get_info()))
+    fn handle_error(&mut self, _db: &dyn Compiler, _state: &mut State, expr: &TError) -> Res {
+        Err(expr.clone())
     }
 }
 

--- a/src/to_cpp.rs
+++ b/src/to_cpp.rs
@@ -475,7 +475,7 @@ impl Visitor<State, Code, Out, Path> for CodeGenerator {
         Err(TError::UnknownInfixOperator(op.to_string(), info))
     }
 
-    fn handle_error(&mut self, _db: &dyn Compiler, _state: &mut State, expr: &Err) -> Res {
-        Err(TError::FailedParse(expr.msg.clone(), expr.get_info()))
+    fn handle_error(&mut self, _db: &dyn Compiler, _state: &mut State, expr: &TError) -> Res {
+        Err(expr.clone())
     }
 }

--- a/src/type_checker.rs
+++ b/src/type_checker.rs
@@ -48,7 +48,7 @@ pub fn infer(db: &dyn Compiler, expr: &Node) -> Result<Type, TError> {
             args: _,
             info: _,
         }) => panic!("TODO Impl type checking for Let"),
-        Error(Err { msg: _, info: _ }) => panic!("TODO Impl type checking for Let"),
+        Error(err) => panic!("TODO Impl type checking for Let {}", err),
     }
 }
 


### PR DESCRIPTION
Removing the Ast `Err` type simplifies error reporting and makes it simple for each visitor to choose whether to postpone Errors with `Ok(Node::Error(error))` or fail on them using `Err(error)`.

This can be done dynamically based on the type of error for each visitor implementation (see `handle_error` in trait `Visitor`)