### PR TITLE
Fix for invalid repl path

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -38,6 +38,7 @@ pub trait Compiler: salsa::Database {
     fn module_name(&self, filename: String) -> Path;
     fn filename(&self, module: Path) -> String;
 
+    // Lexing, parsing and building symbol tables are currently done one whole file at a time.
     fn lex_string(&self, module: Path, contents: Arc<String>) -> Result<VecDeque<Token>, TError>;
     fn lex_file(&self, module: Path) -> Result<VecDeque<Token>, TError>;
     fn parse_string(&self, module: Path, contents: Arc<String>) -> Result<Node, TError>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,7 @@ fn repl(db: &mut DB) -> Result<(), TError> {
                         break;
                     }
                     rl.add_history_entry(line.as_str());
-                    handle(work_on_string(db, line, "repl", None));
+                    handle(work_on_string(db, line, "repl.tk", None));
                 }
             }
             Err(ReadlineError::Interrupted) => {


### PR DESCRIPTION
All file paths should end in a file with a `.tk` extension. This includes the fake path used by the repl.

This fixes a bug that would cause the repl to crash.