### PR TITLE
Remove unit and void

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -6,7 +6,7 @@ use crate::database::Compiler;
 use crate::database::DB;
 use crate::errors::TError;
 use crate::location::*;
-use crate::primitives::Prim;
+use crate::primitives::{Prim, unit_type};
 use crate::tree::*;
 
 impl ToNode for TError {
@@ -84,7 +84,7 @@ impl Sym {
     pub fn as_let(self: &Sym) -> Let {
         Let {
             name: self.name.clone(),
-            value: Box::new(Prim::Unit().to_node()),
+            value: Box::new(unit_type().to_node()),
             args: None,
             info: self.get_info(),
         }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -6,7 +6,7 @@ use crate::database::Compiler;
 use crate::database::DB;
 use crate::errors::TError;
 use crate::location::*;
-use crate::primitives::{Prim, unit_type};
+use crate::primitives::{unit_type, Prim};
 use crate::tree::*;
 
 impl ToNode for TError {

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1,7 +1,7 @@
 use super::ast::*;
 use super::database::Compiler;
 use super::errors::TError;
-use super::primitives::{merge_vals, Frame, Prim, Prim::*, void_type};
+use super::primitives::{merge_vals, void_type, Frame, Prim, Prim::*};
 use std::collections::HashMap;
 
 pub type ImplFn<'a> =

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1,7 +1,7 @@
 use super::ast::*;
 use super::database::Compiler;
 use super::errors::TError;
-use super::primitives::{merge_vals, Frame, Prim, Prim::*};
+use super::primitives::{merge_vals, Frame, Prim, Prim::*, void_type};
 use std::collections::HashMap;
 
 pub type ImplFn<'a> =
@@ -352,7 +352,8 @@ impl<'a> Visitor<State, Prim, Prim> for Interpreter<'a> {
                 if let Some(frame) = state.clone().last() {
                     let mut new_args = vec![];
                     for (arg, ty) in arguments.clone().into_struct().iter() {
-                        let arg_ty = &frame.get(arg).unwrap_or(&Void());
+                        let void = void_type();
+                        let arg_ty = &frame.get(arg).unwrap_or(&void);
                         eprintln!(">> {}: {} unified with {}", &arg, &ty, &arg_ty);
                         let unified = ty.unify(arg_ty, state)?;
                         eprintln!(">>>> {}", &unified);

--- a/src/to_cpp.rs
+++ b/src/to_cpp.rs
@@ -325,8 +325,18 @@ impl Visitor<State, Code, Out, Path> for CodeGenerator {
     fn visit_prim(&mut self, db: &dyn Compiler, state: &mut State, expr: &Prim) -> Res {
         use Prim::*;
         match expr {
-            Void() => Ok(Code::Expr("void".to_string())),
-            Unit() => Ok(Code::Expr("nullptr".to_string())),
+            Product(tys) => {
+                if tys.is_empty() {
+                    return Ok(Code::Expr("void".to_string()));
+                }
+                unimplemented!("unimplemented sum type in compilation to cpp")
+            }
+            Union(tys) => {
+                if tys.is_empty() {
+                    return Ok(Code::Expr("nullptr".to_string()));
+                }
+                unimplemented!("unimplemented sum type in compilation to cpp")
+            }
             I32(n) => Ok(Code::Expr(n.to_string())),
             Bool(true) => Ok(Code::Expr(1.to_string())),
             Bool(false) => Ok(Code::Expr(0.to_string())),

--- a/src/type_checker.rs
+++ b/src/type_checker.rs
@@ -2,12 +2,10 @@ use crate::ast::{Node, Node::*};
 use crate::database::Compiler;
 use crate::errors::TError;
 use crate::interpreter::Interpreter;
-use std::collections::HashMap;
 use std::collections::BTreeSet;
+use std::collections::HashMap;
 
-use crate::primitives::{
-    bit_type, i32_type, record, string_type, Prim, Prim::*,
-};
+use crate::primitives::{bit_type, i32_type, record, string_type, Prim, Prim::*};
 
 pub fn infer(db: &dyn Compiler, expr: &Node, env: &Prim) -> Result<Prim, TError> {
     // Infer that expression t has type A, t => A


### PR DESCRIPTION
Start cleaning up unnecessary type/value representations to increase clarity and make it easier to cover all cases.

The first to go are Unit (which can be represented as `Product(set![])`) and Void (which can be represented as `Union(set![])`). These may return at a later stage as an optimization but for now, it's just duplicated work.