### PR TITLE
Start computing more complex types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 **/gen
 **/*.rs.bk
 *.out
+*.out.*
 *.exe
 out.c
 tako

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,6 @@ rand = "0.7.3"
 
 [profile.test]
 opt-level = 3
+
+[profile.release]
+debug = true

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -315,7 +315,7 @@ impl fmt::Display for Node {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use super::PrettyPrint;
         let db = DB::default();
-        match PrettyPrint::default().visit_root(&db, &self) {
+        match PrettyPrint::default().visit_root(&db, self) {
             Ok(res) => write!(f, "{}", res),
             Err(err) => write!(f, "{:#?}", err),
         }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -164,6 +164,14 @@ impl Let {
             info: self.get_info(),
         }
     }
+    pub fn new(name: &str, value: Val) -> Let {
+        Let {
+            name: name.to_string(),
+            value: Box::new(value.into_node()),
+            args: Some(vec![]),
+            info: Info::default(),
+        }
+    }
 }
 
 impl ToNode for Let {

--- a/src/database.rs
+++ b/src/database.rs
@@ -235,7 +235,7 @@ fn to_file_path(context: PathRef) -> Path {
         match module.last() {
             None => panic!(
                 "Couldn't find a file associated with symbol at {}",
-                path_to_string(&context)
+                path_to_string(context)
             ),
             Some(Symbol::Anon()) => {}                   // Skip anons
             Some(Symbol::Named(_, None)) => {}           // Skip regular symbols

--- a/src/definition_finder.rs
+++ b/src/definition_finder.rs
@@ -23,7 +23,7 @@ impl Visitor<State, Node, Root, Path> for DefinitionFinder {
         if db.debug_level() > 0 {
             eprintln!(
                 "looking up definitions in file... {}",
-                path_to_string(&module)
+                path_to_string(module)
             );
         }
         let mut state = State {
@@ -98,7 +98,7 @@ impl Visitor<State, Node, Root, Path> for DefinitionFinder {
             .args
             .iter()
             .map(|arg| {
-                let val = self.visit_let(db, state, &arg)?.as_let();
+                let val = self.visit_let(db, state, arg)?.as_let();
                 let mut search = state.path.clone();
                 search.push(Symbol::new(&arg.name));
                 let node = state.table.find_mut(&search);
@@ -140,7 +140,7 @@ impl Visitor<State, Node, Root, Path> for DefinitionFinder {
         let args = if let Some(args) = &expr.args {
             Some(
                 args.iter()
-                    .map(|arg| self.visit_let(db, state, &arg)?.as_let())
+                    .map(|arg| self.visit_let(db, state, arg)?.as_let())
                     .collect::<Result<Vec<Let>, TError>>()?,
             )
         } else {

--- a/src/externs.rs
+++ b/src/externs.rs
@@ -6,7 +6,7 @@ use crate::errors::TError;
 use crate::interpreter::{prim_add_strs, prim_pow, Res};
 use crate::primitives::{
     bit_type, builtin, i32_type, int32, number_type, string, string_type, type_type, unit_type,
-    variable, void_type, Prim::*, Val, Val::*,
+    variable, never_type, Prim::*, Val, Val::*,
 };
 
 pub type Args = HashMap<String, Box<dyn Fn() -> Res>>;
@@ -277,7 +277,7 @@ pub fn get_externs(_db: &dyn Compiler) -> Result<HashMap<String, Extern>, TError
             value: builtin("exit"),
             semantic: Func,
             ty: Function {
-                results: Box::new(void_type()),
+                results: Box::new(never_type()),
                 arguments: Box::new(rec! {"it" => i32_type()}),
                 intros: dict!(),
             }.into_node(),
@@ -289,7 +289,7 @@ pub fn get_externs(_db: &dyn Compiler) -> Result<HashMap<String, Extern>, TError
             value: builtin("parse_i32"),
             semantic: Func,
             ty: Function {
-                results: Box::new(Union(set![i32_type(), void_type()])),
+                results: Box::new(Union(set![i32_type(), never_type()])),
                 arguments: Box::new(rec! {"it" => string_type()}),
                 intros: dict!(),
             }.into_node(),
@@ -690,11 +690,11 @@ string to_string(const bool& t){
             cpp: LangImpl::new("void"),
         },
         Extern {
-            name: "Void".to_string(),
-            value: void_type(),
+            name: "Never".to_string(),
+            value: never_type(),
             semantic: Func,
-            ty: variable("Void").into_node(),
-            cpp: LangImpl::new("/*void: should never happen*/ auto"),
+            ty: variable("Never").into_node(),
+            cpp: LangImpl::new("/*Never: should never happen*/ auto"),
         },
         Extern {
             name: "Type".to_string(),

--- a/src/externs.rs
+++ b/src/externs.rs
@@ -5,8 +5,8 @@ use crate::database::Compiler;
 use crate::errors::TError;
 use crate::interpreter::{prim_add_strs, prim_pow, Res};
 use crate::primitives::{
-    bit_type, builtin, i32_type, int32, number_type, string, string_type, type_type, unit_type,
-    variable, never_type, Prim::*, Val, Val::*,
+    bit_type, builtin, i32_type, int32, never_type, number_type, string, string_type, type_type,
+    unit_type, variable, Prim::*, Val, Val::*,
 };
 
 pub type Args = HashMap<String, Box<dyn Fn() -> Res>>;

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -256,7 +256,7 @@ impl<'a> Visitor<State, Val, Val> for Interpreter<'a> {
             eprintln!("evaluating sym {}", expr.clone().into_node());
         }
         let name = &expr.name;
-        let value = find_symbol(&state, name);
+        let value = find_symbol(state, name);
         if let Some(prim) = value {
             if db.debug_level() > 0 {
                 eprintln!("{} = (from stack) {}", name, prim.clone().into_node());
@@ -294,7 +294,7 @@ impl<'a> Visitor<State, Val, Val> for Interpreter<'a> {
             Product(tys) => {
                 let mut new_tys = set![];
                 for ty in tys.iter() {
-                    let new_ty = self.visit_val(db, state, &ty)?; // Evaluate the type
+                    let new_ty = self.visit_val(db, state, ty)?; // Evaluate the type
                     if new_tys.len() == 1 {
                         let ty = new_tys
                             .iter()
@@ -335,7 +335,7 @@ impl<'a> Visitor<State, Val, Val> for Interpreter<'a> {
             Struct(tys) => {
                 let mut new_tys = vec![];
                 for (name, ty) in tys.iter() {
-                    let new_ty = self.visit_val(db, state, &ty)?; // Evaluate the type
+                    let new_ty = self.visit_val(db, state, ty)?; // Evaluate the type
                     new_tys.push((name.clone(), new_ty));
                 }
                 return Ok(Struct(new_tys));

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -2,7 +2,7 @@ use super::ast::*;
 use super::database::Compiler;
 use super::errors::TError;
 use super::primitives::{
-    boolean, int32, merge_vals, string, never_type, Frame, Prim::*, Val, Val::*,
+    boolean, int32, merge_vals, never_type, string, Frame, Prim::*, Val, Val::*,
 };
 use std::collections::HashMap;
 

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -2,7 +2,7 @@ use super::ast::*;
 use super::database::Compiler;
 use super::errors::TError;
 use super::primitives::{
-    boolean, int32, merge_vals, string, void_type, Frame, Prim::*, Val, Val::*,
+    boolean, int32, merge_vals, string, never_type, Frame, Prim::*, Val, Val::*,
 };
 use std::collections::HashMap;
 
@@ -348,8 +348,8 @@ impl<'a> Visitor<State, Val, Val> for Interpreter<'a> {
                 if let Some(frame) = state.clone().last() {
                     let mut new_args = vec![];
                     for (arg, ty) in arguments.clone().into_struct().iter() {
-                        let void = void_type();
-                        let arg_ty = &frame.get(arg).unwrap_or(&void);
+                        let never = never_type();
+                        let arg_ty = &frame.get(arg).unwrap_or(&never);
                         eprintln!(">> {}: {} unified with {}", &arg, &ty, &arg_ty);
                         let unified = ty.unify(arg_ty, state)?;
                         eprintln!(">>>> {}", &unified);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ use std::io::prelude::*;
 use std::sync::Arc;
 
 pub mod ast;
+pub mod tribool;
 pub mod cli_options;
 pub mod database;
 pub mod errors;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,11 +8,11 @@ use std::io::prelude::*;
 use std::sync::Arc;
 
 pub mod ast;
-pub mod tribool;
 pub mod cli_options;
 pub mod database;
 pub mod errors;
 pub mod primitives;
+pub mod tribool;
 
 pub mod interpreter;
 pub mod parser;

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,7 @@ fn main() -> Result<(), TError> {
     db.set_options(Options::new(&args[1..]));
 
     for f in db.options().files.iter() {
-        handle(work(&mut db, &f, None));
+        handle(work(&mut db, f, None));
     }
 
     use takolib::cli_options::Command;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -430,7 +430,7 @@ pub fn parse_string(
 ) -> Result<Node, TError> {
     let toks = db.lex_string(module.to_vec(), text.clone())?;
     if db.debug_level() > 0 {
-        eprintln!("parsing str... {}", path_to_string(&module));
+        eprintln!("parsing str... {}", path_to_string(module));
     }
     let (root, left_over) = expr(db, toks, 0)?;
 
@@ -449,7 +449,7 @@ pub fn parse_string(
 pub fn parse(db: &dyn Compiler, module: PathRef) -> Result<Node, TError> {
     let toks = db.lex_file(module.to_vec())?;
     if db.debug_level() > 0 {
-        eprintln!("parsing file... {}", path_to_string(&module));
+        eprintln!("parsing file... {}", path_to_string(module));
     }
     let (root, left_over) = expr(db, toks, 0)?;
 

--- a/src/pretty_print.rs
+++ b/src/pretty_print.rs
@@ -15,7 +15,7 @@ type State = String;
 impl Visitor<State, (), String, Node> for PrettyPrint {
     fn visit_root(&mut self, db: &dyn Compiler, expr: &Node) -> Result<String, TError> {
         let mut state: String = "".to_string();
-        self.visit(db, &mut state, &expr)?;
+        self.visit(db, &mut state, expr)?;
         Ok(state)
     }
 
@@ -44,7 +44,7 @@ impl Visitor<State, (), String, Node> for PrettyPrint {
             } else {
                 write!(state, ", ")?;
             }
-            self.visit_let(db, state, &arg)?;
+            self.visit_let(db, state, arg)?;
         }
         write!(state, ")")?;
         Ok(())
@@ -69,7 +69,7 @@ impl Visitor<State, (), String, Node> for PrettyPrint {
                 if !is_first {
                     write!(state, ", ")?;
                 }
-                self.visit_let(db, state, &arg)?;
+                self.visit_let(db, state, arg)?;
                 is_first = false;
             }
             write!(state, ")")?;

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -300,19 +300,19 @@ pub fn card(ty: &Val) -> Result<Offset, TError> {
         Union(s) => {
             let mut sum = 0;
             for sty in s {
-                sum += card(&sty)?;
+                sum += card(sty)?;
             }
             Ok(sum)
         }
         Product(s) => {
             let mut prod = 1;
             for sty in s {
-                prod *= card(&sty)?;
+                prod *= card(sty)?;
             }
             Ok(prod)
         }
-        Pointer(_ptr_size, t) => card(&t),
-        Padded(_size, t) => card(&t),
+        Pointer(_ptr_size, t) => card(t),
+        Padded(_size, t) => card(t),
         x => Err(TError::UnknownCardOfAbstractType(
             format!("{:#?}", x),
             Info::default(),
@@ -331,7 +331,7 @@ pub fn size(ty: &Val) -> Result<Offset, TError> {
             let mut res = 0;
             for sty in s.iter() {
                 // This includes padding in size.
-                let c = size(&sty)?;
+                let c = size(sty)?;
                 if res <= c {
                     res = c;
                 }
@@ -341,7 +341,7 @@ pub fn size(ty: &Val) -> Result<Offset, TError> {
         Product(s) => {
             let mut res = 0;
             for sty in s.iter() {
-                let c = size(&sty)?;
+                let c = size(sty)?;
                 if res <= c {
                     res = c;
                 }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -142,18 +142,18 @@ impl Val {
             PrimVal(Prim::BuiltIn(name)) => {
                 panic!("Built in {} does not currently support introspection", name)
             }
-            BitStr(_) | PrimVal(_) => void_type(),
-            Lambda(_) => void_type(),
+            BitStr(_) | PrimVal(_) => never_type(),
+            Lambda(_) => never_type(),
             Struct(tys) => {
                 for (param, ty) in tys.iter() {
                     if param == name {
                         return ty.clone();
                     }
                 }
-                void_type()
+                never_type()
             }
-            Union(_) => void_type(),   // TODO
-            Product(_) => void_type(), // TODO
+            Union(_) => never_type(),   // TODO
+            Product(_) => never_type(), // TODO
             Padded(_, ty) => ty.access(name),
             Pointer(_, ty) => ty.access(name),
             Function {
@@ -163,12 +163,12 @@ impl Val {
             } => match name {
                 "arguments" => *arguments.clone(),
                 "results" => *results.clone(),
-                _ => void_type(),
+                _ => never_type(),
             },
             App {
                 inner: _,
                 arguments: _,
-            } => void_type(), // TODO
+            } => never_type(), // TODO
             WithRequirement(ty, effs) => WithRequirement(Box::new(ty.access(name)), effs.to_vec()),
             Variable(var) => Variable(format!("{}.{}", var, name)),
         }
@@ -210,7 +210,7 @@ impl std::fmt::Debug for Val {
             }
             Union(s) => {
                 if s.is_empty() {
-                    write!(f, "Void")
+                    write!(f, "Never")
                 } else {
                     let mut out = f.debug_tuple("|");
                     for sty in s {
@@ -403,7 +403,7 @@ pub fn sum(values: Vec<Val>) -> Result<Val, TError> {
     Ok(Union(layout))
 }
 
-pub fn void_type() -> Val {
+pub fn never_type() -> Val {
     Union(set![])
 }
 
@@ -512,9 +512,9 @@ mod tests {
     }
 
     #[test]
-    fn void() -> Res {
-        assert_eq!(card(&void_type()), Ok(0));
-        assert_eq!(size(&void_type()), Ok(0));
+    fn never() -> Res {
+        assert_eq!(card(&never_type()), Ok(0));
+        assert_eq!(size(&never_type()), Ok(0));
         Ok(())
     }
     #[test]

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -119,8 +119,15 @@ impl Val {
             Product(tys) => all_true(tys.iter().map(|ty| ty.is_sat())),
             Union(tys) => any_true(tys.iter().map(|ty| ty.is_sat())),
             Padded(_, ty) => ty.is_sat(),
-            Function { intros: _, arguments: _, results } => results.is_sat(), // TODO: arguments?
-            App { inner, arguments: _ } => inner.is_sat(),
+            Function {
+                intros: _,
+                arguments: _,
+                results,
+            } => results.is_sat(), // TODO: arguments?
+            App {
+                inner,
+                arguments: _,
+            } => inner.is_sat(),
             WithRequirement(ty, _reqs) => ty.is_sat(),
             Variable(_name) => True,
             BitStr(_len) => True,

--- a/src/symbol_table_builder.rs
+++ b/src/symbol_table_builder.rs
@@ -68,7 +68,7 @@ impl Visitor<State, Node, Root, Path> for SymbolTableBuilder {
         if db.debug_level() > 0 {
             eprintln!(
                 "building symbol table for file... {}",
-                path_to_string(&module)
+                path_to_string(module)
             );
         }
 
@@ -100,7 +100,7 @@ impl Visitor<State, Node, Root, Path> for SymbolTableBuilder {
         }
 
         Ok(Root {
-            ast: self.visit(db, &mut state, &expr)?,
+            ast: self.visit(db, &mut state, expr)?,
             table: state.table,
         })
     }
@@ -118,7 +118,7 @@ impl Visitor<State, Node, Root, Path> for SymbolTableBuilder {
         let args = expr
             .args
             .iter()
-            .map(|arg| self.visit_let(db, state, &arg)?.as_let())
+            .map(|arg| self.visit_let(db, state, arg)?.as_let())
             .collect::<Result<_, _>>()?;
         let inner = Box::new(self.visit(db, state, &*expr.inner)?);
         state.path.pop();
@@ -168,7 +168,7 @@ impl Visitor<State, Node, Root, Path> for SymbolTableBuilder {
         let args = if let Some(args) = &expr.args {
             Some(
                 args.iter()
-                    .map(|arg| self.visit_let(db, state, &arg)?.as_let())
+                    .map(|arg| self.visit_let(db, state, arg)?.as_let())
                     .collect::<Result<_, _>>()?,
             )
         } else {

--- a/src/to_cpp.rs
+++ b/src/to_cpp.rs
@@ -151,7 +151,7 @@ fn pretty_print_block(src: Code, indent: &str) -> String {
             "{}const auto {} = {};",
             indent,
             name,
-            pretty_print_block(*value, &indent)
+            pretty_print_block(*value, indent)
         ),
         Code::Empty => "".to_string(),
         Code::If {
@@ -159,9 +159,9 @@ fn pretty_print_block(src: Code, indent: &str) -> String {
             then,
             then_else,
         } => {
-            let cond = pretty_print_block(*condition, &indent);
-            let body = pretty_print_block(*then, &indent);
-            let then_else = pretty_print_block(*then_else, &indent);
+            let cond = pretty_print_block(*condition, indent);
+            let body = pretty_print_block(*then, indent);
+            let then_else = pretty_print_block(*then_else, indent);
             format!(
                 "{indent}if({}) {} else {}",
                 cond,
@@ -371,7 +371,7 @@ impl Visitor<State, Code, Out, Path> for CodeGenerator {
         let mut args = vec![];
         for arg in expr.args.iter() {
             // TODO: Include lambda head in values
-            let val = self.visit_let(db, state, &arg)?;
+            let val = self.visit_let(db, state, arg)?;
             match val {
                 Code::Assignment(_, val) => args.push(pretty_print_block(*val, "")),
                 val => args.push(pretty_print_block(val, "")),

--- a/src/tribool.rs
+++ b/src/tribool.rs
@@ -15,7 +15,7 @@ impl fmt::Display for Tribool {
 
 use Tribool::*;
 impl Tribool {
-    pub fn not(self: &Self) -> Self {
+    pub fn not(&self) -> Self {
         match self {
             True => False,
             False => True,
@@ -23,7 +23,7 @@ impl Tribool {
         }
     }
 
-    pub fn or(self: &Self, other: &Self) -> Self {
+    pub fn or(&self, other: &Self) -> Self {
         match (self, other) {
             (True, _) | (_, True) => True,
             (Unknown, _) | (_, Unknown) => Unknown,
@@ -31,7 +31,7 @@ impl Tribool {
         }
     }
 
-    pub fn and(self: &Self, other: &Self) -> Self {
+    pub fn and(&self, other: &Self) -> Self {
         match (self, other) {
             (False, _) | (_, False) => False,
             (Unknown, _) | (_, Unknown) => Unknown,
@@ -39,19 +39,19 @@ impl Tribool {
         }
     }
 
-    pub fn is_true(self: &Self) -> bool {
+    pub fn is_true(&self) -> bool {
         self == &True
     }
-    pub fn maybe_true(self: &Self) -> bool {
+    pub fn maybe_true(&self) -> bool {
         self.is_true() || self.is_unknown()
     }
-    pub fn is_false(self: &Self) -> bool {
+    pub fn is_false(&self) -> bool {
         self == &False
     }
-    pub fn maybe_false(self: &Self) -> bool {
+    pub fn maybe_false(&self) -> bool {
         self.is_false() || self.is_unknown()
     }
-    pub fn is_unknown(self: &Self) -> bool {
+    pub fn is_unknown(&self) -> bool {
         self == &Unknown
     }
 }

--- a/src/tribool.rs
+++ b/src/tribool.rs
@@ -58,7 +58,8 @@ impl Tribool {
 
 pub fn any_true<I>(vals: I) -> Tribool
 where
-    I: Iterator<Item = Tribool> {
+    I: Iterator<Item = Tribool>,
+{
     let mut st = False;
     for i in vals {
         st = st.or(&i);
@@ -68,7 +69,8 @@ where
 
 pub fn all_true<I>(vals: I) -> Tribool
 where
-    I: Iterator<Item = Tribool> {
+    I: Iterator<Item = Tribool>,
+{
     let mut st = True;
     for i in vals {
         st = st.and(&i);

--- a/src/tribool.rs
+++ b/src/tribool.rs
@@ -1,0 +1,77 @@
+use std::fmt;
+
+#[derive(PartialEq, Eq, Clone, PartialOrd, Ord, Hash, Copy, Debug)]
+pub enum Tribool {
+    True,
+    False,
+    Unknown,
+}
+
+impl fmt::Display for Tribool {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+use Tribool::*;
+impl Tribool {
+    pub fn not(self: &Self) -> Self {
+        match self {
+            True => False,
+            False => True,
+            Unknown => Unknown,
+        }
+    }
+
+    pub fn or(self: &Self, other: &Self) -> Self {
+        match (self, other) {
+            (True, _) | (_, True) => True,
+            (Unknown, _) | (_, Unknown) => Unknown,
+            (False, False) => False,
+        }
+    }
+
+    pub fn and(self: &Self, other: &Self) -> Self {
+        match (self, other) {
+            (False, _) | (_, False) => False,
+            (Unknown, _) | (_, Unknown) => Unknown,
+            (True, True) => True,
+        }
+    }
+
+    pub fn is_true(self: &Self) -> bool {
+        self == &True
+    }
+    pub fn maybe_true(self: &Self) -> bool {
+        self.is_true() || self.is_unknown()
+    }
+    pub fn is_false(self: &Self) -> bool {
+        self == &False
+    }
+    pub fn maybe_false(self: &Self) -> bool {
+        self.is_false() || self.is_unknown()
+    }
+    pub fn is_unknown(self: &Self) -> bool {
+        self == &Unknown
+    }
+}
+
+pub fn any_true<I>(vals: I) -> Tribool
+where
+    I: Iterator<Item = Tribool> {
+    let mut st = False;
+    for i in vals {
+        st = st.or(&i);
+    }
+    st
+}
+
+pub fn all_true<I>(vals: I) -> Tribool
+where
+    I: Iterator<Item = Tribool> {
+    let mut st = True;
+    for i in vals {
+        st = st.and(&i);
+    }
+    st
+}

--- a/src/type_graph.rs
+++ b/src/type_graph.rs
@@ -436,8 +436,8 @@ mod tests {
     use crate::ast::{Path, PathRef, Symbol::*};
     use crate::errors::TError;
     use crate::primitives::{
-        bit_type, boolean, byte_type, i32_type, int32, number_type, quad_type, record, string,
-        string_type, sum, trit_type, variable, never_type, Prim::Tag, Val, Val::*,
+        bit_type, boolean, byte_type, i32_type, int32, never_type, number_type, quad_type, record,
+        string, string_type, sum, trit_type, variable, Prim::Tag, Val, Val::*,
     };
     use bitvec::prelude::*;
     use pretty_assertions::assert_eq;

--- a/src/type_graph.rs
+++ b/src/type_graph.rs
@@ -95,7 +95,7 @@ fn cancel_neighbours(tys: TypeSet) -> TypeSet {
     for ty in tys.iter() {
         let mut simpl_tys = set![];
         for other in res.iter().cloned() {
-            simpl_tys.insert(factor_out(other, &ty));
+            simpl_tys.insert(factor_out(other, ty));
         }
         res = simpl_tys;
     }
@@ -151,7 +151,7 @@ fn merge_bit_patterns(tys: TypeSet) -> Option<TypeSet> {
     for b in bits {
         let mut b = b;
         for other in new_bits.clone().iter() {
-            if let Some(overlap) = merge_bit_pattern(&b, &other) {
+            if let Some(overlap) = merge_bit_pattern(&b, other) {
                 if let Some(overlap) = overlap {
                     // merge them
                     new_bits.remove(other);
@@ -313,7 +313,7 @@ impl TypeGraph {
                             vals.push((name.clone(), t.clone()));
                         }
                         (Some(s), Some(t)) => {
-                            vals.push((name.clone(), self.unify(&s, &t)?));
+                            vals.push((name.clone(), self.unify(s, t)?));
                         }
                     }
                 }
@@ -322,7 +322,7 @@ impl TypeGraph {
             (t, Union(tys)) | (Union(tys), t) => {
                 let mut new_tys = set![];
                 for ty in tys.iter() {
-                    let ty = self.unify(ty, &t)?;
+                    let ty = self.unify(ty, t)?;
                     if ty.is_sat().maybe_true() {
                         new_tys.insert(ty);
                     }
@@ -332,7 +332,7 @@ impl TypeGraph {
             (Product(s), ty) | (ty, Product(s)) => {
                 let mut new_tys = set![]; // union find it?
                 for t in s.iter() {
-                    let ty = self.unify(ty, &t)?;
+                    let ty = self.unify(ty, t)?;
                     if ty.is_sat().is_false() {
                         return Ok(never_type());
                     }

--- a/src/type_graph.rs
+++ b/src/type_graph.rs
@@ -1,9 +1,9 @@
 use crate::ast::*;
 use crate::errors::TError;
 use crate::primitives::{never_type, Offset, Prim::*, TypeSet, Val, Val::*};
+use crate::tribool::*;
 use bitvec::prelude::*;
 use std::collections::HashMap;
-use crate::tribool::*;
 
 type Id = i32; // TODO: Make this a vec of Id so it can be treated as a stack
 
@@ -281,7 +281,7 @@ impl TypeGraph {
         let v = self.unify_impl(&from, &to)?;
         let v = self.normalize(v)?;
         // if from == to && from != v {
-            // panic!("wtf\n{}\n{}\n{:#?}", &from, &to, &v);
+        // panic!("wtf\n{}\n{}\n{:#?}", &from, &to, &v);
         // }
         // if v.is_sat().maybe_true() {
         // eprintln!("unified:\n     {}\nwith {}\n to {}", &from, &to, &v);
@@ -1090,7 +1090,9 @@ mod tests {
     #[test]
     fn assignment_to_equal_type_str() -> Test {
         let mut tg = TypeGraph::default();
-        assert!(tg.is_assignable_to(&string_type(), &string_type())?.is_true());
+        assert!(tg
+            .is_assignable_to(&string_type(), &string_type())?
+            .is_true());
         Ok(())
     }
 

--- a/src/type_graph_builder.rs
+++ b/src/type_graph_builder.rs
@@ -26,14 +26,14 @@ impl Visitor<State, Val, TypeGraph, Path> for TypeGraphBuilder {
         if db.debug_level() > 0 {
             eprintln!(
                 "building symbol table & type graph for file... {}",
-                path_to_string(&module)
+                path_to_string(module)
             );
         }
         let mut state = State {
             path: module.clone(),
             graph: TypeGraph::default(),
         };
-        let ty = self.visit(db, &mut state, &expr)?;
+        let ty = self.visit(db, &mut state, expr)?;
         state.graph.require_assignable(&state.path, &ty)?;
         Ok(state.graph)
     }
@@ -55,14 +55,14 @@ impl Visitor<State, Val, TypeGraph, Path> for TypeGraphBuilder {
             Product(vals) => {
                 let mut tys: BTreeSet<Val> = set![];
                 for val in vals.iter() {
-                    tys.insert(self.visit_val(db, state, &val)?);
+                    tys.insert(self.visit_val(db, state, val)?);
                 }
                 Ok(Product(tys))
             }
             Union(vals) => {
                 let mut tys: BTreeSet<Val> = set![];
                 for val in vals.iter() {
-                    tys.insert(self.visit_val(db, state, &val)?);
+                    tys.insert(self.visit_val(db, state, val)?);
                 }
                 Ok(Union(tys))
             }
@@ -71,7 +71,7 @@ impl Visitor<State, Val, TypeGraph, Path> for TypeGraphBuilder {
             PrimVal(Str(_)) => Ok(string_type()),
             Lambda(node) => {
                 state.path.push(Symbol::Anon());
-                let ty = self.visit(db, state, &node);
+                let ty = self.visit(db, state, node);
                 state.path.pop();
                 ty
             }
@@ -90,7 +90,7 @@ impl Visitor<State, Val, TypeGraph, Path> for TypeGraphBuilder {
         state.path.push(Symbol::Anon());
         let mut arg_tys = vec![];
         for arg in &expr.args {
-            let ty = self.visit_let(db, state, &arg)?;
+            let ty = self.visit_let(db, state, arg)?;
             arg_tys.push((arg.name.clone(), ty));
         }
         let result_ty = self.visit(db, state, &*expr.inner)?;
@@ -120,7 +120,7 @@ impl Visitor<State, Val, TypeGraph, Path> for TypeGraphBuilder {
         let args = if let Some(args) = &expr.args {
             let mut arg_tys = vec![];
             for arg in args {
-                let ty = self.visit_let(db, state, &arg)?;
+                let ty = self.visit_let(db, state, arg)?;
                 arg_tys.push((arg.name.clone(), ty));
             }
             Some(arg_tys)

--- a/timing.sh
+++ b/timing.sh
@@ -1,0 +1,1 @@
+cargo test -- --test-threads 1 --report-time -Z unstable-options | sed "s/\(.*\)<\(.*\)>/\2  \1/" | sort -n


### PR DESCRIPTION
- We're starting to run into performance issues with out currently approach (due to unnecessary cloning), start improving this by using is_sat instead of void type equality checks. Ideally this would be cached for each type value)
- Rename void to never to avoid confusion based on C like languages and their naming schemes
- Turn on debug symbols in release mode to improve valgrind, callgrind and cachegrind output