### PR TITLE
Add_externs_to_storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ out.c
 tako
 flamegraph.svg
 perf.data*
+.vscode

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -405,7 +405,7 @@ impl fmt::Debug for Symbol {
 }
 
 macro_rules! symbol {
-    ($name_token: literal) => {
+    ($name_token: tt) => {
         {
         let name: &str = $name_token;
         if name.contains('.') {
@@ -419,7 +419,7 @@ macro_rules! symbol {
 }
 
 macro_rules! path {
-    ($($name:literal),*) => {
+    ($($name:tt),*) => {
        vec![$(symbol!($name),)*]
     };
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -404,6 +404,7 @@ impl fmt::Debug for Symbol {
     }
 }
 
+#[cfg(test)]
 macro_rules! symbol {
     ($name_token: tt) => {{
         let name: &str = $name_token;
@@ -416,6 +417,7 @@ macro_rules! symbol {
     }};
 }
 
+#[cfg(test)]
 macro_rules! path {
     ($($name:tt),*) => {
        vec![$(symbol!($name),)*]

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -405,8 +405,7 @@ impl fmt::Debug for Symbol {
 }
 
 macro_rules! symbol {
-    ($name_token: tt) => {
-        {
+    ($name_token: tt) => {{
         let name: &str = $name_token;
         if name.contains('.') {
             let parts: Vec<&str> = name.splitn(2, '.').collect();
@@ -414,8 +413,7 @@ macro_rules! symbol {
         } else {
             crate::ast::Symbol::new(name)
         }
-    }
-    }
+    }};
 }
 
 macro_rules! path {

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -404,6 +404,26 @@ impl fmt::Debug for Symbol {
     }
 }
 
+macro_rules! symbol {
+    ($name_token: literal) => {
+        {
+        let name: &str = $name_token;
+        if name.contains('.') {
+            let parts: Vec<&str> = name.splitn(2, '.').collect();
+            crate::ast::Symbol::with_ext(parts[0], parts[1])
+        } else {
+            crate::ast::Symbol::new(name)
+        }
+    }
+    }
+}
+
+macro_rules! path {
+    ($($name:literal),*) => {
+       vec![$(symbol!($name),)*]
+    };
+}
+
 impl fmt::Display for Symbol {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {

--- a/src/components.rs
+++ b/src/components.rs
@@ -15,17 +15,6 @@ pub struct DefinedAt(pub Option<Path>);
 #[storage(VecStorage)]
 pub struct InstancesAt(pub BTreeSet<Loc>);
 
-impl InstancesAt {
-    #[cfg(test)]
-    pub fn new(loc: Loc) -> Self {
-        Self(set![loc])
-    }
-
-    pub fn loc(file: &str, line: i32, col: i32) -> Self {
-        Self(set![Loc::new(file, line, col)])
-    }
-}
-
 impl std::fmt::Debug for InstancesAt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "InstancesAt(")?;

--- a/src/components.rs
+++ b/src/components.rs
@@ -20,6 +20,10 @@ impl InstancesAt {
     pub fn new(loc: Loc) -> Self {
         Self(set![loc])
     }
+
+    pub fn loc(file: &str, line: i32, col: i32) -> Self {
+        Self(set![Loc::new(file, line, col)])
+    }
 }
 
 impl std::fmt::Debug for InstancesAt {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,9 @@ mod pretty_assertions;
 
 #[macro_use]
 pub mod data_structures;
-
+#[macro_use]
 pub mod ast;
+
 pub mod cli_options;
 pub mod database;
 pub mod errors;

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -203,7 +203,14 @@ impl<T: Matcher<Res = Vec<Entity>>, U: Matcher<Res = Vec<Entity>>> Matcher for E
             .map_err(|err| ExpectErrorInFollowUp(Box::new(err)))?;
         let mut errs = l_errs;
         errs.extend(r_errs);
-        if left != right {
+        let mut failed = false;
+        for l in left.iter() {
+            if !right.contains(l) { // TODO: This is O(n), could be O(1)
+                failed = true;
+                break;
+            }
+        }
+        if failed {
             return Err(ExpectationNotMetVec(left, right).because(errs));
         }
         Ok((left, errs))

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -1,10 +1,10 @@
+use crate::components::InstancesAt;
 use crate::database::DBStorage;
 use crate::errors::{RequirementError, RequirementErrors};
+use crate::location::Loc;
 use derivative::Derivative;
 use specs::Entity;
 use thiserror::Error;
-use crate::components::InstancesAt;
-use crate::location::Loc;
 
 #[derive(Error, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Derivative)]
 #[derivative(Debug)]
@@ -104,12 +104,11 @@ pub trait Matcher {
     }
 
     fn at(self, file_name: &str, line: i32, col: i32) -> Expect<Self, InstancesAt>
-        where
+    where
         Self: Sized + Matcher<Res = Vec<Entity>>,
-        {
-            self.expect(InstancesAt(set!(Loc::new(file_name, line, col))))
-        }
-
+    {
+        self.expect(InstancesAt(set!(Loc::new(file_name, line, col))))
+    }
 }
 
 pub struct One<T: Matcher<Res = Vec<Entity>>>(T);
@@ -205,7 +204,8 @@ impl<T: Matcher<Res = Vec<Entity>>, U: Matcher<Res = Vec<Entity>>> Matcher for E
         errs.extend(r_errs);
         let mut failed = false;
         for l in left.iter() {
-            if !right.contains(l) { // TODO: This is O(n), could be O(1)
+            if !right.contains(l) {
+                // TODO: This is O(n), could be O(1)
                 failed = true;
                 break;
             }

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -3,6 +3,8 @@ use crate::errors::{RequirementError, RequirementErrors};
 use derivative::Derivative;
 use specs::Entity;
 use thiserror::Error;
+use crate::components::InstancesAt;
+use crate::location::Loc;
 
 #[derive(Error, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Derivative)]
 #[derivative(Debug)]
@@ -100,6 +102,14 @@ pub trait Matcher {
             second: other,
         }
     }
+
+    fn at(self, file_name: &str, line: i32, col: i32) -> Expect<Self, InstancesAt>
+        where
+        Self: Sized + Matcher<Res = Vec<Entity>>,
+        {
+            self.expect(InstancesAt(set!(Loc::new(file_name, line, col))))
+        }
+
 }
 
 pub struct One<T: Matcher<Res = Vec<Entity>>>(T);

--- a/src/passes/parser.rs
+++ b/src/passes/parser.rs
@@ -581,7 +581,6 @@ pub mod tests {
     use super::*;
     use crate::components::*;
     use crate::errors::TError;
-    use crate::location::Loc;
     use crate::matcher::Matcher;
     use crate::primitives::{int32, string};
     use pretty_assertions::assert_eq;
@@ -833,7 +832,7 @@ pub mod tests {
     fn entity_parse_num() -> Test {
         let (root, storage) = parse_entities("12")?;
         assert_eq_err(
-            InstancesAt::new(Loc::new("test.tk", 1, 1))
+            InstancesAt::loc("test.tk", 1, 1)
                 .expect(HasValue::new(Prim::I32(12)))
                 .one()
                 .run(&storage),
@@ -846,15 +845,15 @@ pub mod tests {
         let (_root, storage) = parse_entities("12 : Int")?;
         assert_no_err(
             SymbolRef {
-                name: vec![Symbol::new("Int")],
-                context: vec![Symbol::with_ext("test", "tk")],
+                name: path!("Int"),
+                context: path!("test.tk"),
                 definition: None,
             }
-            .expect(InstancesAt::new(Loc::new("test.tk", 1, 6)))
+            .expect(InstancesAt::loc("test.tk", 1, 6))
             .one()
             .chain(|ty_id| {
                 HasValue::new(Prim::I32(12))
-                    .expect(InstancesAt::new(Loc::new("test.tk", 1, 1)))
+                    .expect(InstancesAt::loc("test.tk", 1, 1))
                     .expect(HasType(*ty_id))
                     .one()
             })


### PR DESCRIPTION
Working towards merging extern definitions into the storage without braking all the tests.

This lays more groundwork for re-writing tests using a matching system rather than just dumping all info into a string.