### PR TITLE
Add externs to storage

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -7,6 +7,7 @@ use crate::errors::TError;
 use crate::location::Loc;
 use crate::primitives::{unit_type, Val};
 use crate::symbol_table::Table;
+use specs::Entity;
 
 use TError::{
     CppCompilerError, ExpectedLetNode, InternalError, MatchError, OutOfScopeTypeVariable,
@@ -408,7 +409,9 @@ impl fmt::Debug for Symbol {
 macro_rules! symbol {
     ($name_token: tt) => {{
         let name: &str = $name_token;
-        if name.contains('.') {
+        if name == "_" {
+            crate::ast::Symbol::Anon
+        } else if name.contains('.') {
             let parts: Vec<&str> = name.splitn(2, '.').collect();
             crate::ast::Symbol::with_ext(parts[0], parts[1])
         } else {
@@ -499,6 +502,7 @@ impl Default for Entry {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Root {
     pub ast: Node,
+    pub entity: Entity,
     pub table: Table,
 }
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -13,14 +13,15 @@ use TError::{
     CppCompilerError, ExpectedLetNode, InternalError, MatchError, OutOfScopeTypeVariable,
     ParseError, RequirementFailure, StackInterpreterRanOutOfArguments,
     StackInterpreterRanOutOfCode, StaticPointerCardinality, TypeMismatch, TypeMismatch2,
-    UnknownCardOfAbstractType, UnknownEntity, UnknownInfixOperator, UnknownPath,
-    UnknownPrefixOperator, UnknownSizeOfAbstractType, UnknownSizeOfVariableType, UnknownSymbol,
-    UnknownToken,
+    UnfinishedCodeGeneration, UnknownCardOfAbstractType, UnknownEntity, UnknownInfixOperator,
+    UnknownPath, UnknownPrefixOperator, UnknownSizeOfAbstractType, UnknownSizeOfVariableType,
+    UnknownSymbol, UnknownToken,
 };
 impl HasInfo for TError {
     fn get_info(&self) -> &Info {
         match self {
-            CppCompilerError(_, _, info)
+            UnfinishedCodeGeneration(_, info)
+            | CppCompilerError(_, _, info)
             | UnknownToken(_, info, _)
             | UnknownSymbol(_, info, _)
             | OutOfScopeTypeVariable(_, info)
@@ -45,7 +46,8 @@ impl HasInfo for TError {
     }
     fn get_mut_info(&mut self) -> &mut Info {
         match self {
-            CppCompilerError(_, _, ref mut info)
+            UnfinishedCodeGeneration(_, ref mut info)
+            | CppCompilerError(_, _, ref mut info)
             | UnknownToken(_, ref mut info, _)
             | UnknownSymbol(_, ref mut info, _)
             | OutOfScopeTypeVariable(_, ref mut info)

--- a/src/components.rs
+++ b/src/components.rs
@@ -7,10 +7,6 @@ use specs::Component;
 use std::collections::BTreeSet;
 
 // TODO: Use macro for defining and registering each of these.
-#[derive(Component, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
-#[storage(VecStorage)]
-pub struct DefinedAt(pub Option<Path>);
-
 #[derive(Component, Clone, Eq, PartialEq, PartialOrd, Ord, Hash)]
 #[storage(VecStorage)]
 pub struct InstancesAt(pub BTreeSet<Loc>);

--- a/src/cpp_ast.rs
+++ b/src/cpp_ast.rs
@@ -1,0 +1,101 @@
+#[derive(Clone, Debug)]
+pub enum Code {
+    Empty,
+    Block(Vec<Code>),
+    Struct(Vec<Code>),
+    Expr(String),
+    Statement(String),
+    Template(String, Box<Code>),
+    Assignment(String, Box<Code>),
+    If {
+        condition: Box<Code>,
+        then: Box<Code>,
+        then_else: Box<Code>,
+    },
+    Func {
+        name: String,
+        args: Vec<String>,
+        return_type: String,
+        body: Box<Code>,
+        lambda: bool,
+        call: bool,
+    },
+}
+
+impl Code {
+    pub fn with_expr(self: Code, f: &dyn Fn(String) -> Code) -> Code {
+        match self {
+            Code::Empty => Code::Empty,
+            Code::Expr(expr) => f(expr),
+            Code::Struct(values) => Code::Struct(values),
+            Code::Block(mut statements) => {
+                let last = statements.pop().expect("Unexpected empty code block");
+                statements.push(last.with_expr(f));
+                Code::Block(statements)
+            }
+            Code::Statement(line) => Code::Statement(line),
+            Code::Template(name, body) => Code::Template(name, Box::new(body.with_expr(f))),
+            Code::Assignment(name, value) => Code::Assignment(name, Box::new(value.with_expr(f))),
+            Code::If {
+                condition,
+                then,
+                then_else,
+            } => Code::If {
+                condition,
+                then,
+                then_else,
+            },
+            Code::Func {
+                name,
+                args,
+                mut body,
+                lambda,
+                call,
+                return_type,
+            } => {
+                body = Box::new(body.with_expr(f));
+                Code::Func {
+                    name,
+                    args,
+                    body,
+                    lambda,
+                    call,
+                    return_type,
+                }
+            }
+        }
+    }
+
+    pub fn merge(self: Code, other: Code) -> Code {
+        match (self, other) {
+            (Code::Empty, right) => right,
+            (left, Code::Empty) => left,
+            (Code::Block(mut left), Code::Block(right)) => {
+                left.extend(right);
+                Code::Block(left)
+            }
+            (mut left, Code::Block(mut right)) => {
+                if let Code::Expr(expr) = left {
+                    left = Code::Statement(expr);
+                }
+                right.insert(0, left);
+                Code::Block(right) // Backwards?
+            }
+            (Code::Block(mut left), right) => {
+                for line in &mut left {
+                    if let Code::Expr(expr) = line {
+                        *line = Code::Statement(expr.clone());
+                    }
+                }
+                left.push(right);
+                Code::Block(left)
+            }
+            (mut left, right) => {
+                if let Code::Expr(expr) = left {
+                    left = Code::Statement(expr);
+                }
+                Code::Block(vec![left, right])
+            }
+        }
+    }
+}

--- a/src/cpp_ast.rs
+++ b/src/cpp_ast.rs
@@ -1,5 +1,8 @@
+use specs::Entity;
+
 #[derive(Clone, Debug)]
 pub enum Code {
+    Partial(Entity),
     Empty,
     Block(Vec<Code>),
     Struct(Vec<Code>),
@@ -25,6 +28,7 @@ pub enum Code {
 impl Code {
     pub fn with_expr(self: Code, f: &dyn Fn(String) -> Code) -> Code {
         match self {
+            Code::Partial(ent) => Code::Partial(ent),
             Code::Empty => Code::Empty,
             Code::Expr(expr) => f(expr),
             Code::Struct(values) => Code::Struct(values),

--- a/src/database.rs
+++ b/src/database.rs
@@ -200,7 +200,7 @@ impl Default for DBStorage {
 
         // Register builtins.
         for (name, ext) in empty.get_externs() {
-            let path = vec![Symbol::new(&name)];
+            let path = vec![Symbol::new(name)];
             let entry = AstNode {
                 term: AstTerm::Symbol {
                     name: path.clone(),

--- a/src/database.rs
+++ b/src/database.rs
@@ -211,7 +211,7 @@ impl Default for DBStorage {
                 ty: None,            // TODO: use ext.ty,
             };
             empty.store_node(entry, &path);
-         }
+        }
         empty
     }
 }
@@ -338,7 +338,10 @@ impl DBStorage {
         DefinitionFinder::process(&module, self)
     }
 
-    pub fn compile_to_cpp(&mut self, module: PathRef) -> Result<(String, HashSet<String>, (String, HashSet<String>)), TError> {
+    pub fn compile_to_cpp(
+        &mut self,
+        module: PathRef,
+    ) -> Result<(String, HashSet<String>, (String, HashSet<String>)), TError> {
         use crate::passes::to_cpp::CodeGenerator;
         info!("Generating code... {}", path_to_string(module));
         CodeGenerator::process(&module.to_vec(), self)

--- a/src/database.rs
+++ b/src/database.rs
@@ -195,7 +195,6 @@ impl Default for DBStorage {
             ast_to_entity: HashMap::default(),
             path_to_entity: HashMap::default(),
             defined_at: HashMap::default(),
-            // refers_to: HashMap::default(),
             instance_at: HashMap::default(),
         }
     }

--- a/src/database.rs
+++ b/src/database.rs
@@ -187,7 +187,7 @@ impl Default for DBStorage {
         register_components(&mut world);
 
         let project_dirs = ProjectDirs::from("systems", "mimir", "tako");
-        Self {
+        let mut empty = Self {
             world,
             project_dirs,
             options: Options::default(),
@@ -196,7 +196,23 @@ impl Default for DBStorage {
             path_to_entity: HashMap::default(),
             defined_at: HashMap::default(),
             instance_at: HashMap::default(),
-        }
+        };
+
+        // Register builtins.
+        for (name, ext) in empty.get_externs() {
+            let path = vec![Symbol::new(&name)];
+            let entry = AstNode {
+                term: AstTerm::Symbol {
+                    name: path.clone(),
+                    context: vec![],
+                    value: Some(ext.value.clone()),
+                },
+                loc: Loc::default(), // TODO: Make locations for externs
+                ty: None,            // TODO: use ext.ty,
+            };
+            empty.store_node(entry, &path);
+         }
+        empty
     }
 }
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -20,6 +20,8 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::sync::Arc;
 
+pub type CompilationResult = (String, HashSet<String>);
+
 fn to_file_path(context: PathRef) -> Path {
     let mut module = context.to_vec();
     loop {
@@ -341,14 +343,14 @@ impl DBStorage {
     pub fn compile_to_cpp(
         &mut self,
         module: PathRef,
-    ) -> Result<(String, HashSet<String>, (String, HashSet<String>)), TError> {
+    ) -> Result<(CompilationResult, CompilationResult), TError> {
         use crate::passes::to_cpp::CodeGenerator;
         info!("Generating code... {}", path_to_string(module));
         CodeGenerator::process(&module.to_vec(), self)
     }
 
     pub fn build_with_gpp(&mut self, module: PathRef) -> Result<String, TError> {
-        let (res, flags, (entity_res, entity_flags)) = self.compile_to_cpp(module)?;
+        let ((res, flags), (entity_res, entity_flags)) = self.compile_to_cpp(module)?;
         info!("Building file with g++ ... {}", path_to_string(module));
         info!("Alternative {:?} {:?}", entity_res, entity_flags);
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -2,8 +2,7 @@ use crate::ast::{path_to_string, Info, Node, Path, PathRef, Root, Symbol, Visito
 use crate::ast_node::*;
 use crate::cli_options::Options;
 use crate::components::{
-    Call, DefinedAt, Definition, HasErrors, HasType, HasValue, InstancesAt, Sequence, SymbolRef,
-    Untyped,
+    Call, Definition, HasErrors, HasType, HasValue, InstancesAt, Sequence, SymbolRef, Untyped,
 };
 use crate::errors::{RequirementError, TError};
 use crate::externs::{get_externs, Extern, Semantic};
@@ -149,7 +148,6 @@ macro_rules! define_components {
 
 define_components!(
     call => Call,
-    defined_at => DefinedAt,
     definition => Definition,
     has_errors => HasErrors,
     has_type => HasType,
@@ -164,7 +162,6 @@ define_debug!(
     format_entity_definition,
     print_entity_definition,
     format_entity_definitions,
-    DefinedAt,
     Definition,
     SymbolRef
 );
@@ -184,6 +181,8 @@ define_debug!(
 
 impl Default for DBStorage {
     fn default() -> Self {
+        #[cfg(test)]
+        crate::init_for_test();
         let mut world = World::new();
         register_components(&mut world);
 
@@ -283,16 +282,20 @@ impl DBStorage {
         &mut self,
         module: PathRef,
         contents: &Arc<String>,
-    ) -> Result<Node, TError> {
+    ) -> Result<(Node, Entity), TError> {
         use crate::passes::parser;
-        Ok(parser::parse_string(self, module, contents)?.0)
+        parser::parse_string(self, module, contents)
     }
 
-    pub fn parse_str(&mut self, module: PathRef, contents: &'static str) -> Result<Node, TError> {
+    pub fn parse_str(
+        &mut self,
+        module: PathRef,
+        contents: &'static str,
+    ) -> Result<(Node, Entity), TError> {
         self.parse_string(module, &Arc::new(contents.to_string()))
     }
 
-    pub fn parse_file(&mut self, module: PathRef) -> Result<Node, TError> {
+    pub fn parse_file(&mut self, module: PathRef) -> Result<(Node, Entity), TError> {
         info!("Parsing file... {}", path_to_string(module));
         let filename = self.filename(module);
         let contents = if let Some(contents) = self.file_contents.get(&filename) {
@@ -320,15 +323,16 @@ impl DBStorage {
         DefinitionFinder::process(&module, self)
     }
 
-    pub fn compile_to_cpp(&mut self, module: PathRef) -> Result<(String, HashSet<String>), TError> {
+    pub fn compile_to_cpp(&mut self, module: PathRef) -> Result<(String, HashSet<String>, (String, HashSet<String>)), TError> {
         use crate::passes::to_cpp::CodeGenerator;
         info!("Generating code... {}", path_to_string(module));
         CodeGenerator::process(&module.to_vec(), self)
     }
 
     pub fn build_with_gpp(&mut self, module: PathRef) -> Result<String, TError> {
-        let (res, flags) = self.compile_to_cpp(module)?;
+        let (res, flags, (entity_res, entity_flags)) = self.compile_to_cpp(module)?;
         info!("Building file with g++ ... {}", path_to_string(module));
+        info!("Alternative {:?} {:?}", entity_res, entity_flags);
 
         let name: String = module
             .iter()
@@ -521,13 +525,11 @@ impl DBStorage {
                         context,
                         value,
                     } => {
-                        let entity = entity
-                            .with(SymbolRef {
-                                name,
-                                context,
-                                definition: None,
-                            })
-                            .with(DefinedAt(None));
+                        let entity = entity.with(SymbolRef {
+                            name,
+                            context,
+                            definition: None,
+                        });
                         if let Some(value) = value {
                             entity.with(HasValue(value))
                         } else {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -9,6 +9,8 @@ use derivative::Derivative;
 #[derive(Error, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Derivative)]
 #[derivative(Debug)]
 pub enum TError {
+    #[error("unfinished conversion to cpp, entity: {0:?}")]
+    UnfinishedCodeGeneration(Entity, Info),
     #[error("call to C++ compiler failed with error code: {1:?}\n{0}")]
     CppCompilerError(String, Option<i32>, Info),
     #[error("unknown token `{0:?}` in {2:?} at {1}")]

--- a/src/experimental/type_graph_builder.rs
+++ b/src/experimental/type_graph_builder.rs
@@ -30,7 +30,7 @@ pub struct State {
 
 impl Visitor<State, Val, TypeGraph, Path> for TypeGraphBuilder {
     fn visit_root(&mut self, storage: &mut DBStorage, module: &Path) -> Result<TypeGraph, TError> {
-        let expr = &storage.parse_file(module)?;
+        let (expr, _entity) = &storage.parse_file(module)?;
         info!(
             "Building symbol table & type graph... {}",
             path_to_string(module)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,8 @@ mod pretty_assertions;
 pub mod data_structures;
 #[macro_use]
 pub mod ast;
+#[macro_use]
+pub mod cpp_ast;
 
 pub mod cli_options;
 pub mod database;

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -74,7 +74,7 @@ pub trait Matcher {
         NoMatches(self)
     }
 
-    fn chain<U: Matcher>(self, other: impl Fn(&Self::Res) -> U + 'static) -> Chain<Self, U>
+    fn with<U: Matcher>(self, other: impl Fn(&Self::Res) -> U + 'static) -> Chain<Self, U>
     where
         Self: Sized,
     {

--- a/src/passes/definition_finder.rs
+++ b/src/passes/definition_finder.rs
@@ -247,7 +247,7 @@ mod tests {
         assert_no_err(
             HasValue::new(Prim::I32(23))
                 .one()
-                .chain(|n_23| {
+                .with(|n_23| {
                     Definition {
                         names: vec![path!("x")],
                         params: None,
@@ -256,7 +256,7 @@ mod tests {
                     }
                     .one()
                 })
-                .chain(|(_n_23, n_x)| {
+                .with(|(_n_23, n_x)| {
                     SymbolRef {
                         name: path!("x"),
                         context: test_path(),
@@ -275,7 +275,7 @@ mod tests {
         assert_no_err(
             HasValue::new(Prim::I32(45))
                 .one()
-                .chain(|n_23| {
+                .with(|n_23| {
                     Definition {
                         names: vec![path!("x")],
                         params: None,
@@ -284,7 +284,7 @@ mod tests {
                     }
                     .one()
                 })
-                .chain(|(_n_23, n_x)| {
+                .with(|(_n_23, n_x)| {
                     SymbolRef {
                         name: path!("x"),
                         context: test_path_and(path!("y")),

--- a/src/passes/definition_finder.rs
+++ b/src/passes/definition_finder.rs
@@ -2,7 +2,7 @@ use crate::ast::{
     path_to_string, Abs, Apply, BinOp, HasInfo, Let, Node, Path, Root, Sym, Symbol, ToNode, UnOp,
     Visitor,
 };
-use crate::components::{DefinedAt, SymbolRef};
+use crate::components::SymbolRef;
 use crate::database::DBStorage;
 use crate::errors::TError;
 use crate::externs::get_externs;
@@ -24,18 +24,18 @@ struct DefinitionFinderSystem {
 }
 
 impl<'a> System<'a> for DefinitionFinderSystem {
-    type SystemData = (ReadStorage<'a, SymbolRef>, WriteStorage<'a, DefinedAt>);
+    type SystemData = WriteStorage<'a, SymbolRef>;
 
-    fn run(&mut self, (symbols, mut defined_at_map): Self::SystemData) {
+    fn run(&mut self, mut symbols: Self::SystemData) {
         // dbg!(&self.path_to_entity);
-        for (symbol, defined_at) in (&symbols, &mut defined_at_map).join() {
+        for symbol in (&mut symbols).join() {
             let get_entity = || {
                 let mut context = symbol.context.clone();
                 loop {
                     let mut search_path = context.clone();
                     search_path.extend(symbol.name.clone());
                     if let Some(entity) = self.path_to_entity.get(&search_path) {
-                        return Some((entity, search_path));
+                        return Some((*entity, search_path));
                     }
                     if context.is_empty() {
                         return None;
@@ -43,7 +43,7 @@ impl<'a> System<'a> for DefinitionFinderSystem {
                     context.pop(); // go back
                 }
             };
-            if defined_at.0 != None {
+            if symbol.definition != None {
                 continue; // this one is 'pre' defined
             }
             if let Some((entity, found_path)) = get_entity() {
@@ -51,10 +51,11 @@ impl<'a> System<'a> for DefinitionFinderSystem {
                     "Found symbol: {:?} -> {:?} @ {:?}",
                     &symbol, &entity, &found_path
                 );
-                defined_at.0 = Some(found_path);
+                symbol.definition = Some(entity);
             } else if let Some(ext) = get_externs().get(&path_to_string(&symbol.name)) {
                 debug!("Found extern: {:?} -> {:?}", &symbol, &ext);
-                defined_at.0 = Some(symbol.name.clone());
+                // TODO
+                // symbol.definition = Some(symbol.name.clone());
             } else {
                 debug!("Couldn't find symbol: {:?}", &symbol);
             }
@@ -64,20 +65,23 @@ impl<'a> System<'a> for DefinitionFinderSystem {
 
 impl Visitor<State, Node, Root, Path> for DefinitionFinder {
     fn visit_root(&mut self, storage: &mut DBStorage, module: &Path) -> Result<Root, TError> {
-        let expr = storage.build_symbol_table(module)?;
+        let root = storage.build_symbol_table(module)?;
         info!("Looking up definitions... {}", path_to_string(module));
         let mut definition_finder = DefinitionFinderSystem {
             path_to_entity: storage.path_to_entity.clone(),
         };
+        debug!("Running definition_finder");
         definition_finder.run_now(&storage.world);
+        debug!("Done definition_finder");
 
         let mut state = State {
             path: module.clone(),
-            table: expr.table.clone(),
+            table: root.table.clone(),
         };
-        let ast = self.visit(storage, &mut state, &expr.ast)?;
+        let ast = self.visit(storage, &mut state, &root.ast)?;
         Ok(Root {
             ast,
+            entity: root.entity,
             table: state.table,
         })
     }
@@ -214,92 +218,87 @@ impl Visitor<State, Node, Root, Path> for DefinitionFinder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::components::*;
     use crate::database::DBStorage;
+    use crate::errors::TError;
+    use crate::matcher::Matcher;
+    use crate::pretty_assertions::assert_no_err;
+    use crate::primitives::Prim;
 
     type Test = Result<(), TError>;
 
-    fn symbols_found_using(
-        storage: &mut DBStorage,
-        prog_str: &'static str,
-    ) -> Result<String, TError> {
-        let prog_filename = "test/prog.tk";
-        storage.set_file(prog_filename, prog_str.to_owned());
-        let prog_module = storage.module_name(prog_filename);
-
-        let Root { ast, table } = DefinitionFinder::process(&prog_module, storage)?;
-
-        debug!("{:?}", ast);
-
-        Ok(format!(
-            "{:?}",
-            table
-                .find(&prog_module)
-                .expect("couldn't find definitions for test file")
-        ))
+    static TEST_FN: &str = "test/prog.tk";
+    fn test_path() -> Path {
+        path!("test", "prog.tk")
     }
 
-    fn assert_symbols_found(prog_str: &'static str, matches: &'static str) -> Test {
+    fn test_path_and(suffix: Path) -> Path {
+        let mut path = test_path();
+        path.extend(suffix);
+        path
+    }
+
+    fn find_definitions_entities(contents: &str) -> Result<(Entity, DBStorage), TError> {
         let mut storage = DBStorage::default();
-        let prog_definitions = symbols_found_using(&mut storage, prog_str)?;
-        assert_str_eq!(prog_definitions, matches);
+        storage.set_file(TEST_FN, contents.to_owned());
+        let module = storage.module_name(TEST_FN);
+        let root = DefinitionFinder::process(&module, &mut storage)?;
+        Ok((root.entity, storage))
+    }
+
+    #[test]
+    fn matcher_use_local_definition() -> Test {
+        let (_root, storage) = find_definitions_entities("x=23;x")?;
+        assert_no_err(
+            HasValue::new(Prim::I32(23))
+                .one()
+                .chain(|n_23| {
+                    Definition {
+                        names: vec![path!("x")],
+                        params: None,
+                        implementations: vec![*n_23],
+                        path: test_path(),
+                    }
+                    .one()
+                })
+                .chain(|(_n_23, n_x)| {
+                    SymbolRef {
+                        name: path!("x"),
+                        context: test_path(),
+                        definition: Some(*n_x),
+                    }
+                    .one()
+                })
+                .run(&storage),
+        )?;
         Ok(())
     }
 
     #[test]
-    fn use_local_definition() -> Test {
-        assert_symbols_found(
-            "x=23;x",
-            "Entry { uses: {}, defined_at: [] } {
-    main: Entry { uses: {[test, prog.tk]}, defined_at: [] },
-    x: Entry { uses: {[test, prog.tk]}, defined_at: [] },
-}",
-        )
-    }
-
-    #[test]
-    fn entity_use_local_definition() -> Test {
-        let mut storage = DBStorage::default();
-        let _definitions = symbols_found_using(&mut storage, "x=23;x")?;
-        assert_str_eq!(storage.format_entity_definitions(),
-            "\
-Entity 0:
-Entity 1:
- - Definition { names: [[x]], params: None, implementations: [Entity(0, Generation(1))], path: [test, prog.tk] }
-Entity 2:
- - DefinedAt(Some([test, prog.tk, x]))
- - SymbolRef { name: [x], context: [test, prog.tk], definition: None }
-Entity 3:
- - DefinedAt(Some([;]))
- - SymbolRef { name: [;], context: [test, prog.tk], definition: None }
-Entity 4:");
-        Ok(())
-    }
-
-    #[test]
-    fn entity_use_closest_definition() -> Test {
-        let mut storage = DBStorage::default();
-        let _definitions = symbols_found_using(&mut storage, "x=23;y=(x=45;x)")?;
-        assert_str_eq!(storage.format_entity_definitions(),
-            "\
-Entity 0:
-Entity 1:
- - Definition { names: [[x]], params: None, implementations: [Entity(0, Generation(1))], path: [test, prog.tk] }
-Entity 2:
-Entity 3:
- - Definition { names: [[x]], params: None, implementations: [Entity(2, Generation(1))], path: [test, prog.tk, y] }
-Entity 4:
- - DefinedAt(Some([test, prog.tk, y, x]))
- - SymbolRef { name: [x], context: [test, prog.tk, y], definition: None }
-Entity 5:
- - DefinedAt(Some([;]))
- - SymbolRef { name: [;], context: [test, prog.tk, y], definition: None }
-Entity 6:
-Entity 7:
- - Definition { names: [[y]], params: None, implementations: [Entity(6, Generation(1))], path: [test, prog.tk] }
-Entity 8:
- - DefinedAt(Some([;]))
- - SymbolRef { name: [;], context: [test, prog.tk], definition: None }
-Entity 9:");
+    fn matcher_use_closest_definition() -> Test {
+        let (_root, storage) = find_definitions_entities("x=23;y=(x=45;x)")?;
+        assert_no_err(
+            HasValue::new(Prim::I32(45))
+                .one()
+                .chain(|n_23| {
+                    Definition {
+                        names: vec![path!("x")],
+                        params: None,
+                        implementations: vec![*n_23],
+                        path: test_path_and(path!("y")),
+                    }
+                    .one()
+                })
+                .chain(|(_n_23, n_x)| {
+                    SymbolRef {
+                        name: path!("x"),
+                        context: test_path_and(path!("y")),
+                        definition: Some(*n_x),
+                    }
+                    .one()
+                })
+                .run(&storage),
+        )?;
         Ok(())
     }
 }

--- a/src/passes/definition_finder.rs
+++ b/src/passes/definition_finder.rs
@@ -5,7 +5,6 @@ use crate::ast::{
 use crate::components::SymbolRef;
 use crate::database::DBStorage;
 use crate::errors::TError;
-use crate::externs::get_externs;
 use crate::passes::symbol_table_builder::State;
 use crate::primitives::Val;
 use log::{debug, info};
@@ -35,7 +34,11 @@ impl<'a> System<'a> for DefinitionFinderSystem {
                     let mut search_path = context.clone();
                     search_path.extend(symbol.name.clone());
                     if let Some(entity) = self.path_to_entity.get(&search_path) {
-                        return Some((*entity, search_path));
+                        debug!(
+                            "Found symbol: {:?} -> {:?} @ {:?}",
+                            &symbol, &entity, &search_path
+                        );
+                        return Some(*entity);
                     }
                     if context.is_empty() {
                         return None;
@@ -46,16 +49,8 @@ impl<'a> System<'a> for DefinitionFinderSystem {
             if symbol.definition != None {
                 continue; // this one is 'pre' defined
             }
-            if let Some((entity, found_path)) = get_entity() {
-                debug!(
-                    "Found symbol: {:?} -> {:?} @ {:?}",
-                    &symbol, &entity, &found_path
-                );
+            if let Some(entity) = get_entity() {
                 symbol.definition = Some(entity);
-            } else if let Some(ext) = get_externs().get(&path_to_string(&symbol.name)) {
-                debug!("Found extern: {:?} -> {:?}", &symbol, &ext);
-                // TODO
-                // symbol.definition = Some(symbol.name.clone());
             } else {
                 debug!("Couldn't find symbol: {:?}", &symbol);
             }

--- a/src/passes/parser.rs
+++ b/src/passes/parser.rs
@@ -610,7 +610,7 @@ pub mod tests {
         assert_eq_err(
             SymbolRef::new(path!("Int"), path!(TEST_FN))
                 .at(TEST_FN, 1, 6)
-                .chain(|ty_id| {
+                .with(|ty_id| {
                     HasValue::new(Prim::I32(12))
                         .expect(HasType(*ty_id))
                         .at(TEST_FN, 1, 1)
@@ -630,7 +630,7 @@ pub mod tests {
         let int_ty = SymbolRef::new(path!("Int"), path!(TEST_FN)).at(TEST_FN, 1, 9);
         assert_eq_err(
             (((node_3, node_mul), node_4), int_ty)
-                .chain(|(((n_3, n_mul), n_4), n_ty)| {
+                .with(|(((n_3, n_mul), n_4), n_ty)| {
                     Call::new(*n_mul, &[*n_3, *n_4])
                         .expect(HasType(*n_ty))
                         .at(TEST_FN, 1, 3)
@@ -646,7 +646,7 @@ pub mod tests {
         let (root, storage) = parse_entities("3 * (4 : Int)")?;
         let node_3 = HasValue::new(Prim::I32(3)).at(TEST_FN, 1, 1);
         let int_ty = SymbolRef::new(path!("Int"), path!(TEST_FN)).at(TEST_FN, 1, 10);
-        let node_4 = int_ty.chain(|n_ty| {
+        let node_4 = int_ty.with(|n_ty| {
             HasValue::new(Prim::I32(4))
                 .expect(HasType(*n_ty))
                 .at(TEST_FN, 1, 6)
@@ -654,7 +654,7 @@ pub mod tests {
         let node_mul = SymbolRef::new(path!("*"), path!(TEST_FN)).at(TEST_FN, 1, 3);
         assert_eq_err(
             ((node_3, node_mul), node_4)
-                .chain(|((n_3, n_mul), (_n_ty, n_4))| {
+                .with(|((n_3, n_mul), (_n_ty, n_4))| {
                     Call::new(*n_mul, &[*n_3, *n_4]).at(TEST_FN, 1, 3)
                 })
                 .run(&storage)
@@ -672,7 +672,7 @@ pub mod tests {
         let node_mul = SymbolRef::new(path!("*"), path!(TEST_FN)).at(TEST_FN, 1, 4);
         assert_eq_err(
             (((node_3, node_mul), node_4), node_12)
-                .chain(|(((n_3, n_mul), n_4), n_12)| {
+                .with(|(((n_3, n_mul), n_4), n_12)| {
                     Call::new(*n_mul, &[*n_3, *n_4])
                         .expect(HasType(*n_12))
                         .at(TEST_FN, 1, 4)
@@ -701,7 +701,7 @@ pub mod tests {
         assert_eq_err(
             SymbolRef::new(path!("String"), path!(TEST_FN))
                 .at(TEST_FN, 1, 17)
-                .chain(|ty_id| {
+                .with(|ty_id| {
                     HasValue::new(Prim::Str("hello world".to_string()))
                         .expect(HasType(*ty_id))
                         .at(TEST_FN, 1, 1)
@@ -719,7 +719,7 @@ pub mod tests {
         let node_neg = SymbolRef::new(path!("-"), path!(TEST_FN)).at(TEST_FN, 1, 1);
         assert_eq_err(
             (node_12, node_neg)
-                .chain(|(n_12, n_neg)| Call::new(*n_neg, &[*n_12]).at(TEST_FN, 1, 1))
+                .with(|(n_12, n_neg)| Call::new(*n_neg, &[*n_12]).at(TEST_FN, 1, 1))
                 .run(&storage)
                 .map(|res| res.1),
             root,
@@ -734,7 +734,7 @@ pub mod tests {
         let node_neg = SymbolRef::new(path!("-"), path!(TEST_FN)).at(TEST_FN, 1, 3);
         assert_eq_err(
             ((node_12, node_neg), node_14)
-                .chain(|((n_12, n_neg), n_14)| Call::new(*n_neg, &[*n_14, *n_12]).at(TEST_FN, 1, 3))
+                .with(|((n_12, n_neg), n_14)| Call::new(*n_neg, &[*n_14, *n_12]).at(TEST_FN, 1, 3))
                 .run(&storage)
                 .map(|res| res.1),
             root,
@@ -749,7 +749,7 @@ pub mod tests {
         let node_pls = SymbolRef::new(path!("+"), path!(TEST_FN)).at(TEST_FN, 1, 3);
         assert_eq_err(
             ((node_12, node_pls), node_14)
-                .chain(|((n_12, n_pls), n_14)| Call::new(*n_pls, &[*n_14, *n_12]).at(TEST_FN, 1, 3))
+                .with(|((n_12, n_pls), n_14)| Call::new(*n_pls, &[*n_14, *n_12]).at(TEST_FN, 1, 3))
                 .run(&storage)
                 .map(|res| res.1),
             root,
@@ -766,10 +766,10 @@ pub mod tests {
         let node_4 = HasValue::new(Prim::I32(4)).at(TEST_FN, 1, 5);
         assert_eq_err(
             ((((node_3, node_pls), node_2), node_mul), node_4)
-                .chain(|((((_n_3, _n_pls), n_2), n_mul), n_4)| {
+                .with(|((((_n_3, _n_pls), n_2), n_mul), n_4)| {
                     Call::new(*n_mul, &[*n_2, *n_4]).at(TEST_FN, 1, 4)
                 })
-                .chain(|(((((n_3, n_pls), _n_2), _n_mul), _n_4), n_8)| {
+                .with(|(((((n_3, n_pls), _n_2), _n_mul), _n_4), n_8)| {
                     Call::new(*n_pls, &[*n_3, *n_8]).at(TEST_FN, 1, 2)
                 })
                 .run(&storage)
@@ -789,14 +789,14 @@ pub mod tests {
         assert_eq_err(
             (
                 (
-                    ((node_3, node_mul), node_2).chain(|((n_3, n_mul), n_2)| {
+                    ((node_3, node_mul), node_2).with(|((n_3, n_mul), n_2)| {
                         Call::new(*n_mul, &[*n_3, *n_2]).at(TEST_FN, 1, 2)
                     }),
                     node_pls,
                 ),
                 node_4,
             )
-                .chain(|(((_, n_6), n_pls), n_4)| {
+                .with(|(((_, n_6), n_pls), n_4)| {
                     Call::new(*n_pls, &[*n_6, *n_4]).at(TEST_FN, 1, 4)
                 })
                 .run(&storage)
@@ -816,11 +816,11 @@ pub mod tests {
         assert_eq_err(
             (
                 (node_3, node_mul),
-                ((node_2, node_pls), node_4).chain(|((n_2, n_pls), n_4)| {
+                ((node_2, node_pls), node_4).with(|((n_2, n_pls), n_4)| {
                     Call::new(*n_pls, &[*n_2, *n_4]).at(TEST_FN, 1, 5)
                 }),
             )
-                .chain(|((n_3, n_mul), (_, n_6))| {
+                .with(|((n_3, n_mul), (_, n_6))| {
                     Call::new(*n_mul, &[*n_3, *n_6]).at(TEST_FN, 1, 2)
                 })
                 .run(&storage)
@@ -837,7 +837,7 @@ pub mod tests {
         let node_pls = SymbolRef::new(path!("+"), path!(TEST_FN)).at(TEST_FN, 1, 8);
         assert_eq_err(
             ((node_hello, node_pls), node_world)
-                .chain(|((n_h, n_pls), n_w)| Call::new(*n_pls, &[*n_h, *n_w]).at(TEST_FN, 1, 8))
+                .with(|((n_h, n_pls), n_w)| Call::new(*n_pls, &[*n_h, *n_w]).at(TEST_FN, 1, 8))
                 .run(&storage)
                 .map(|res| res.1),
             root,
@@ -851,7 +851,7 @@ pub mod tests {
         let node_7 = HasValue::new(Prim::I32(7)).at(TEST_FN, 2, 1);
         assert_eq_err(
             (node_hello, node_7)
-                .chain(|(n_h, n_7)| Sequence(vec![*n_h, *n_7]).at(TEST_FN, 2, 1))
+                .with(|(n_h, n_7)| Sequence(vec![*n_h, *n_7]).at(TEST_FN, 2, 1))
                 .run(&storage)
                 .map(|res| res.1),
             root,
@@ -865,7 +865,7 @@ pub mod tests {
         let node_f = SymbolRef::new(path!("f"), path!(TEST_FN)).at(TEST_FN, 1, 1);
         assert_eq_err(
             (
-                node_hello.chain(|n_h| {
+                node_hello.with(|n_h| {
                     Definition {
                         names: vec![path!("arg")],
                         params: None,
@@ -876,7 +876,7 @@ pub mod tests {
                 }),
                 node_f,
             )
-                .chain(|((_n_h, n_a), n_f)| {
+                .with(|((_n_h, n_a), n_f)| {
                     Call {
                         inner: *n_f,
                         args: vec![*n_a],
@@ -897,14 +897,14 @@ pub mod tests {
         let node_x = SymbolRef::new(path!("x"), path!(TEST_FN, "mul")).at(TEST_FN, 1, 12);
         let node_mul = SymbolRef::new(path!("*"), path!(TEST_FN, "mul")).at(TEST_FN, 1, 13);
         let node_y = SymbolRef::new(path!("y"), path!(TEST_FN, "mul")).at(TEST_FN, 1, 14);
-        let res = ((node_x, node_mul), node_y).chain(|((n_x, n_mul), n_y)| {
+        let res = ((node_x, node_mul), node_y).with(|((n_x, n_mul), n_y)| {
             Call {
                 inner: *n_mul,
                 args: vec![*n_x, *n_y],
             }
             .at(TEST_FN, 1, 13)
         });
-        let def = ((arg_x, arg_y), res).chain(|((n_x, n_y), (_, n_r))| {
+        let def = ((arg_x, arg_y), res).with(|((n_x, n_y), (_, n_r))| {
             Definition {
                 names: vec![path!("mul")],
                 params: Some(vec![*n_x, *n_y]),
@@ -921,14 +921,14 @@ pub mod tests {
         let (root, storage) = parse_entities("x()= !\"hello world\";\n7")?;
         let node_hello = HasValue::new(Prim::Str("hello world".to_string())).at(TEST_FN, 1, 7);
         let node_not = SymbolRef::new(path!("!"), path!(TEST_FN, "x")).at(TEST_FN, 1, 6);
-        let x_impl = (node_hello, node_not).chain(|(n_h, n_n)| {
+        let x_impl = (node_hello, node_not).with(|(n_h, n_n)| {
             Call {
                 inner: *n_n,
                 args: vec![*n_h],
             }
             .at(TEST_FN, 1, 6)
         });
-        let x_def = x_impl.chain(|(_n_h, n_i)| {
+        let x_def = x_impl.with(|(_n_h, n_i)| {
             Definition {
                 names: vec![path!("x")],
                 params: Some(vec![]),
@@ -941,7 +941,7 @@ pub mod tests {
         let node_semi = SymbolRef::new(path!(";"), path!(TEST_FN)).at(TEST_FN, 1, 20);
         assert_eq_err(
             ((x_def, node_semi), node_7)
-                .chain(|(((_, n_d), n_s), n_7)| {
+                .with(|(((_, n_d), n_s), n_7)| {
                     Call {
                         inner: *n_s,
                         args: vec![*n_d, *n_7],

--- a/src/passes/parser.rs
+++ b/src/passes/parser.rs
@@ -582,255 +582,21 @@ pub mod tests {
     use crate::components::*;
     use crate::errors::TError;
     use crate::matcher::Matcher;
-    use crate::primitives::{int32, string};
-    use pretty_assertions::assert_eq;
+    use crate::pretty_assertions::assert_eq_err;
 
     type Test = Result<(), TError>;
 
     static TEST_FN: &str = "test.tk";
 
-    fn parse_impl(storage: &mut DBStorage, contents: &str) -> Result<(Node, Entity), TError> {
-        let module = storage.module_name(TEST_FN);
-        parse_string(storage, &module, &Arc::new(contents.to_string()))
-    }
-
-    fn parse(contents: &str) -> Result<Node, TError> {
-        let mut storage = DBStorage::default();
-        Ok(parse_impl(&mut storage, contents)?.0)
-    }
-
-    fn dbg_parse_entities(contents: &str) -> Result<String, TError> {
-        Ok(parse_entities(contents)?.1.format_entities())
-    }
-
     fn parse_entities(contents: &str) -> Result<(Entity, DBStorage), TError> {
         let mut storage = DBStorage::default();
-        let root = parse_impl(&mut storage, contents)?.1;
+        let module = storage.module_name(TEST_FN);
+        let root = parse_string(&mut storage, &module, &Arc::new(contents.to_string()))?.1;
         Ok((root, storage))
-    }
-
-    fn num_lit(x: i32) -> Box<Node> {
-        Box::new(int32(x).into_node())
-    }
-
-    fn str_lit(x: &str) -> Box<Node> {
-        Box::new(string(x).into_node())
     }
 
     #[test]
     fn parse_num() -> Test {
-        assert_eq!(parse("12")?, int32(12).into_node());
-        Ok(())
-    }
-
-    #[test]
-    fn parse_str() -> Test {
-        assert_eq!(parse("\"hello world\"")?, string("hello world").into_node());
-        Ok(())
-    }
-
-    #[test]
-    fn parse_un_op() -> Test {
-        assert_eq!(
-            parse("-12")?,
-            UnOp {
-                name: "-".to_string(),
-                inner: Box::new(int32(12).into_node()),
-                info: Info::default()
-            }
-            .into_node()
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn parse_min_op() -> Test {
-        assert_eq!(
-            parse("14-12")?,
-            BinOp {
-                name: "-".to_string(),
-                left: num_lit(14),
-                right: num_lit(12),
-                info: Info::default()
-            }
-            .into_node()
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn parse_mul_op() -> Test {
-        assert_eq!(
-            parse("14*12")?,
-            BinOp {
-                name: "*".to_string(),
-                left: num_lit(14),
-                right: num_lit(12),
-                info: Info::default()
-            }
-            .into_node()
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn parse_add_mul_precedence() -> Test {
-        assert_eq!(
-            parse("3+2*4")?,
-            BinOp {
-                name: "+".to_string(),
-                left: num_lit(3),
-                right: Box::new(
-                    BinOp {
-                        name: "*".to_string(),
-                        left: num_lit(2),
-                        right: num_lit(4),
-                        info: Info::default()
-                    }
-                    .into_node()
-                ),
-                info: Info::default()
-            }
-            .into_node()
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn parse_mul_add_precedence() -> Test {
-        assert_eq!(
-            parse("3*2+4")?,
-            BinOp {
-                name: "+".to_string(),
-                left: Box::new(
-                    BinOp {
-                        name: "*".to_string(),
-                        left: num_lit(3),
-                        right: num_lit(2),
-                        info: Info::default()
-                    }
-                    .into_node()
-                ),
-                right: num_lit(4),
-                info: Info::default()
-            }
-            .into_node()
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn parse_mul_add_parens() -> Test {
-        assert_eq!(
-            parse("3*(2+4)")?,
-            BinOp {
-                name: "*".to_string(),
-                left: num_lit(3),
-                right: Box::new(
-                    BinOp {
-                        name: "+".to_string(),
-                        left: num_lit(2),
-                        right: num_lit(4),
-                        info: Info::default()
-                    }
-                    .into_node()
-                ),
-                info: Info::default()
-            }
-            .into_node()
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn parse_add_str() -> Test {
-        assert_eq!(
-            parse("\"hello\"+\" world\"")?,
-            BinOp {
-                name: "+".to_string(),
-                left: str_lit("hello"),
-                right: str_lit(" world"),
-                info: Info::default()
-            }
-            .into_node()
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn parse_strings_followed_by_raw_values() -> Test {
-        assert_eq!(
-            parse("\"hello world\"\n7")?,
-            BinOp {
-                name: ",".to_string(),
-                left: Box::new(str_lit("hello world").into_node()),
-                right: num_lit(7),
-                info: Info::default()
-            }
-            .into_node()
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn parse_strings_with_operators_and_trailing_values_in_let() -> Test {
-        assert_eq!(
-            parse("x()= !\"hello world\";\n7")?,
-            BinOp {
-                name: ";".to_string(),
-                left: Box::new(
-                    Let {
-                        name: "x".to_string(),
-                        args: Some(vec![]),
-                        value: Box::new(
-                            UnOp {
-                                name: "!".to_string(),
-                                inner: str_lit("hello world"),
-                                info: Info::default(),
-                            }
-                            .into_node()
-                        ),
-                        info: Info::default(),
-                    }
-                    .into_node()
-                ),
-                right: num_lit(7),
-                info: Info::default()
-            }
-            .into_node()
-        );
-        Ok(())
-    }
-
-    fn log_err<T, E: std::fmt::Display>(res: Result<T, E>) -> Result<T, E> {
-        res.map_err(|err| {
-            eprintln!("{0}", &err);
-            err
-        })
-    }
-
-    fn assert_no_err<T: std::fmt::Debug, E: std::fmt::Display>(
-        res: Result<T, E>,
-    ) -> Result<(), TError>
-    where
-        TError: From<E>,
-    {
-        Ok(log_err(res).map(|_| ())?)
-    }
-
-    fn assert_eq_err<T: PartialEq + std::fmt::Debug, E: std::fmt::Display>(
-        res: Result<T, E>,
-        rhs: T,
-    ) -> Result<(), TError>
-    where
-        TError: From<E>,
-    {
-        assert_eq!(log_err(res)?, rhs);
-        Ok(())
-    }
-
-    #[test]
-    fn entity_parse_num() -> Test {
         let (root, storage) = parse_entities("12")?;
         assert_eq_err(
             HasValue::new(Prim::I32(12)).at(TEST_FN, 1, 1).run(&storage),
@@ -839,28 +605,24 @@ pub mod tests {
     }
 
     #[test]
-    fn entity_parse_num_with_type_annotation() -> Test {
+    fn parse_num_with_type_annotation() -> Test {
         let (root, storage) = parse_entities("12 : Int")?;
         assert_eq_err(
-            SymbolRef {
-                name: path!("Int"),
-                context: path!(TEST_FN),
-                definition: None,
-            }
-            .at(TEST_FN, 1, 6)
-            .chain(|ty_id| {
-                HasValue::new(Prim::I32(12))
-                    .expect(HasType(*ty_id))
-                    .at(TEST_FN, 1, 1)
-            })
-            .run(&storage)
-            .map(|res| res.1),
+            SymbolRef::new(path!("Int"), path!(TEST_FN))
+                .at(TEST_FN, 1, 6)
+                .chain(|ty_id| {
+                    HasValue::new(Prim::I32(12))
+                        .expect(HasType(*ty_id))
+                        .at(TEST_FN, 1, 1)
+                })
+                .run(&storage)
+                .map(|res| res.1),
             root,
         )
     }
 
     #[test]
-    fn entity_parse_expr_with_type_annotation() -> Test {
+    fn parse_expr_with_type_annotation() -> Test {
         let (root, storage) = parse_entities("3 * 4 : Int")?;
         let node_3 = HasValue::new(Prim::I32(3)).at(TEST_FN, 1, 1);
         let node_mul = SymbolRef::new(path!("*"), path!(TEST_FN)).at(TEST_FN, 1, 3);
@@ -880,7 +642,7 @@ pub mod tests {
     }
 
     #[test]
-    fn entity_parse_expr_containing_value_with_type_annotation() -> Test {
+    fn parse_expr_containing_value_with_type_annotation() -> Test {
         let (root, storage) = parse_entities("3 * (4 : Int)")?;
         let node_3 = HasValue::new(Prim::I32(3)).at(TEST_FN, 1, 1);
         let int_ty = SymbolRef::new(path!("Int"), path!(TEST_FN)).at(TEST_FN, 1, 10);
@@ -902,7 +664,7 @@ pub mod tests {
     }
 
     #[test]
-    fn entity_parse_expr_with_value_type_annotation() -> Test {
+    fn parse_expr_with_value_type_annotation() -> Test {
         let (root, storage) = parse_entities("(3 * 4) : 12")?;
         let node_3 = HasValue::new(Prim::I32(3)).at(TEST_FN, 1, 2);
         let node_4 = HasValue::new(Prim::I32(4)).at(TEST_FN, 1, 6);
@@ -922,7 +684,7 @@ pub mod tests {
     }
 
     #[test]
-    fn entity_parse_str() -> Test {
+    fn parse_str() -> Test {
         let (root, storage) = parse_entities("\"hello world\"")?;
         let txt = "hello world".to_string();
         assert_eq_err(
@@ -934,7 +696,7 @@ pub mod tests {
     }
 
     #[test]
-    fn entity_parse_str_with_type_annotation() -> Test {
+    fn parse_str_with_type_annotation() -> Test {
         let (root, storage) = parse_entities("\"hello world\" : String")?;
         assert_eq_err(
             SymbolRef::new(path!("String"), path!(TEST_FN))
@@ -951,7 +713,7 @@ pub mod tests {
     }
 
     #[test]
-    fn entity_parse_un_op() -> Test {
+    fn parse_un_op() -> Test {
         let (root, storage) = parse_entities("-12")?;
         let node_12 = HasValue::new(Prim::I32(12)).at(TEST_FN, 1, 2);
         let node_neg = SymbolRef::new(path!("-"), path!(TEST_FN)).at(TEST_FN, 1, 1);
@@ -965,7 +727,7 @@ pub mod tests {
     }
 
     #[test]
-    fn entity_parse_min_op() -> Test {
+    fn parse_min_op() -> Test {
         let (root, storage) = parse_entities("14-12")?;
         let node_12 = HasValue::new(Prim::I32(12)).at(TEST_FN, 1, 4);
         let node_14 = HasValue::new(Prim::I32(14)).at(TEST_FN, 1, 1);
@@ -980,7 +742,7 @@ pub mod tests {
     }
 
     #[test]
-    fn entity_parse_mul_op() -> Test {
+    fn parse_mul_op() -> Test {
         let (root, storage) = parse_entities("14+12")?;
         let node_12 = HasValue::new(Prim::I32(12)).at(TEST_FN, 1, 4);
         let node_14 = HasValue::new(Prim::I32(14)).at(TEST_FN, 1, 1);
@@ -995,7 +757,7 @@ pub mod tests {
     }
 
     #[test]
-    fn entity_parse_add_mul_precedence() -> Test {
+    fn parse_add_mul_precedence() -> Test {
         let (root, storage) = parse_entities("3+2*4")?;
         let node_3 = HasValue::new(Prim::I32(3)).at(TEST_FN, 1, 1);
         let node_pls = SymbolRef::new(path!("+"), path!(TEST_FN)).at(TEST_FN, 1, 2);
@@ -1017,7 +779,7 @@ pub mod tests {
     }
 
     #[test]
-    fn entity_parse_mul_add_precedence() -> Test {
+    fn parse_mul_add_precedence() -> Test {
         let (root, storage) = parse_entities("3*2+4")?;
         let node_3 = HasValue::new(Prim::I32(3)).at(TEST_FN, 1, 1);
         let node_mul = SymbolRef::new(path!("*"), path!(TEST_FN)).at(TEST_FN, 1, 2);
@@ -1044,163 +806,151 @@ pub mod tests {
     }
 
     #[test]
-    fn entity_parse_mul_add_parens() -> Test {
-        assert_str_eq!(
-            dbg_parse_entities("3*(2+4)")?,
-            "\
-Entity 0:
- - HasValue(3)
- - InstancesAt(test.tk:1:1)
-Entity 1:
- - HasValue(2)
- - InstancesAt(test.tk:1:4)
-Entity 2:
- - HasValue(4)
- - InstancesAt(test.tk:1:6)
-Entity 3:
- - DefinedAt(None)
- - SymbolRef { name: [+], context: [test.tk], definition: None }
- - InstancesAt(test.tk:1:5)
-Entity 4:
- - Call { inner: Entity(3, Generation(1)), args: [Entity(1, Generation(1)), Entity(2, Generation(1))] }
- - InstancesAt(test.tk:1:5)
-Entity 5:
- - DefinedAt(None)
- - SymbolRef { name: [*], context: [test.tk], definition: None }
- - InstancesAt(test.tk:1:2)
-Entity 6:
- - Call { inner: Entity(5, Generation(1)), args: [Entity(0, Generation(1)), Entity(4, Generation(1))] }
- - InstancesAt(test.tk:1:2)"
-        );
-        Ok(())
+    fn parse_mul_add_parens() -> Test {
+        let (root, storage) = parse_entities("3*(2+4)")?;
+        let node_3 = HasValue::new(Prim::I32(3)).at(TEST_FN, 1, 1);
+        let node_mul = SymbolRef::new(path!("*"), path!(TEST_FN)).at(TEST_FN, 1, 2);
+        let node_2 = HasValue::new(Prim::I32(2)).at(TEST_FN, 1, 4);
+        let node_pls = SymbolRef::new(path!("+"), path!(TEST_FN)).at(TEST_FN, 1, 5);
+        let node_4 = HasValue::new(Prim::I32(4)).at(TEST_FN, 1, 6);
+        assert_eq_err(
+            (
+                (node_3, node_mul),
+                ((node_2, node_pls), node_4).chain(|((n_2, n_pls), n_4)| {
+                    Call::new(*n_pls, &[*n_2, *n_4]).at(TEST_FN, 1, 5)
+                }),
+            )
+                .chain(|((n_3, n_mul), (_, n_6))| {
+                    Call::new(*n_mul, &[*n_3, *n_6]).at(TEST_FN, 1, 2)
+                })
+                .run(&storage)
+                .map(|res| res.1),
+            root,
+        )
     }
 
     #[test]
-    fn entity_parse_add_str() -> Test {
-        assert_str_eq!(
-            dbg_parse_entities("\"hello\"+\" world\"")?,
-            "\
-Entity 0:
- - HasValue('hello')
- - InstancesAt(test.tk:1:1)
-Entity 1:
- - HasValue(' world')
- - InstancesAt(test.tk:1:9)
-Entity 2:
- - DefinedAt(None)
- - SymbolRef { name: [+], context: [test.tk], definition: None }
- - InstancesAt(test.tk:1:8)
-Entity 3:
- - Call { inner: Entity(2, Generation(1)), args: [Entity(0, Generation(1)), Entity(1, Generation(1))] }
- - InstancesAt(test.tk:1:8)"
-        );
-        Ok(())
+    fn parse_add_str() -> Test {
+        let (root, storage) = parse_entities("\"hello\"+\" world\"")?;
+        let node_hello = HasValue::new(Prim::Str("hello".to_string())).at(TEST_FN, 1, 1);
+        let node_world = HasValue::new(Prim::Str(" world".to_string())).at(TEST_FN, 1, 9);
+        let node_pls = SymbolRef::new(path!("+"), path!(TEST_FN)).at(TEST_FN, 1, 8);
+        assert_eq_err(
+            ((node_hello, node_pls), node_world)
+                .chain(|((n_h, n_pls), n_w)| Call::new(*n_pls, &[*n_h, *n_w]).at(TEST_FN, 1, 8))
+                .run(&storage)
+                .map(|res| res.1),
+            root,
+        )
     }
 
     #[test]
-    fn entity_parse_strings_followed_by_raw_values() -> Test {
-        assert_str_eq!(
-            dbg_parse_entities("\"hello world\"\n7")?,
-            "\
-Entity 0:
- - HasValue('hello world')
- - InstancesAt(test.tk:1:1)
-Entity 1:
- - HasValue(7)
- - InstancesAt(test.tk:2:1)
-Entity 2:
- - Sequence([Entity(0, Generation(1)), Entity(1, Generation(1))])
- - InstancesAt(test.tk:2:1)"
-        );
-        Ok(())
+    fn parse_strings_followed_by_raw_values() -> Test {
+        let (root, storage) = parse_entities("\"hello world\"\n7")?;
+        let node_hello = HasValue::new(Prim::Str("hello world".to_string())).at(TEST_FN, 1, 1);
+        let node_7 = HasValue::new(Prim::I32(7)).at(TEST_FN, 2, 1);
+        assert_eq_err(
+            (node_hello, node_7)
+                .chain(|(n_h, n_7)| Sequence(vec![*n_h, *n_7]).at(TEST_FN, 2, 1))
+                .run(&storage)
+                .map(|res| res.1),
+            root,
+        )
     }
 
     #[test]
-    fn entity_parse_kwargs() -> Test {
-        assert_str_eq!(
-            dbg_parse_entities("f(arg=\"hello world\")")?,
-            "\
-Entity 0:
- - HasValue('hello world')
- - InstancesAt(test.tk:1:7)
-Entity 1:
- - Definition { names: [[arg]], params: None, implementations: [Entity(0, Generation(1))], path: [test.tk, _] }
- - InstancesAt(test.tk:1:3)
-Entity 2:
- - DefinedAt(None)
- - SymbolRef { name: [f], context: [test.tk], definition: None }
- - InstancesAt(test.tk:1:1)
-Entity 3:
- - Call { inner: Entity(2, Generation(1)), args: [Entity(1, Generation(1))] }
- - InstancesAt(test.tk:1:1)"
-        );
-        Ok(())
+    fn parse_kwargs() -> Test {
+        let (root, storage) = parse_entities("f(arg=\"hello world\")")?;
+        let node_hello = HasValue::new(Prim::Str("hello world".to_string())).at(TEST_FN, 1, 7);
+        let node_f = SymbolRef::new(path!("f"), path!(TEST_FN)).at(TEST_FN, 1, 1);
+        assert_eq_err(
+            (
+                node_hello.chain(|n_h| {
+                    Definition {
+                        names: vec![path!("arg")],
+                        params: None,
+                        implementations: vec![*n_h],
+                        path: path!(TEST_FN, "_"),
+                    }
+                    .at(TEST_FN, 1, 3)
+                }),
+                node_f,
+            )
+                .chain(|((_n_h, n_a), n_f)| {
+                    Call {
+                        inner: *n_f,
+                        args: vec![*n_a],
+                    }
+                    .at(TEST_FN, 1, 1)
+                })
+                .run(&storage)
+                .map(|res| res.1),
+            root,
+        )
     }
 
     #[test]
-    fn entity_parse_mul_functions() -> Test {
-        assert_str_eq!(
-            dbg_parse_entities("mul(x, y)= x*y")?,
-            "\
-Entity 0:
- - DefinedAt(None)
- - SymbolRef { name: [x], context: [test.tk, _], definition: None }
- - InstancesAt(test.tk:1:5)
-Entity 1:
- - DefinedAt(None)
- - SymbolRef { name: [y], context: [test.tk, _], definition: None }
- - InstancesAt(test.tk:1:8)
-Entity 2:
- - DefinedAt(None)
- - SymbolRef { name: [x], context: [test.tk, mul], definition: None }
- - InstancesAt(test.tk:1:12)
-Entity 3:
- - DefinedAt(None)
- - SymbolRef { name: [y], context: [test.tk, mul], definition: None }
- - InstancesAt(test.tk:1:14)
-Entity 4:
- - DefinedAt(None)
- - SymbolRef { name: [*], context: [test.tk, mul], definition: None }
- - InstancesAt(test.tk:1:13)
-Entity 5:
- - Call { inner: Entity(4, Generation(1)), args: [Entity(2, Generation(1)), Entity(3, Generation(1))] }
- - InstancesAt(test.tk:1:13)
-Entity 6:
- - Definition { names: [[mul]], params: Some([Entity(0, Generation(1)), Entity(1, Generation(1))]), implementations: [Entity(5, Generation(1))], path: [test.tk] }
- - InstancesAt(test.tk:1:1)"
-        );
-        Ok(())
+    fn parse_mul_functions() -> Test {
+        let (root, storage) = parse_entities("mul(x, y)= x*y")?;
+        let arg_x = SymbolRef::new(path!("x"), path!(TEST_FN, "_")).at(TEST_FN, 1, 5);
+        let arg_y = SymbolRef::new(path!("y"), path!(TEST_FN, "_")).at(TEST_FN, 1, 8);
+        let node_x = SymbolRef::new(path!("x"), path!(TEST_FN, "mul")).at(TEST_FN, 1, 12);
+        let node_mul = SymbolRef::new(path!("*"), path!(TEST_FN, "mul")).at(TEST_FN, 1, 13);
+        let node_y = SymbolRef::new(path!("y"), path!(TEST_FN, "mul")).at(TEST_FN, 1, 14);
+        let res = ((node_x, node_mul), node_y).chain(|((n_x, n_mul), n_y)| {
+            Call {
+                inner: *n_mul,
+                args: vec![*n_x, *n_y],
+            }
+            .at(TEST_FN, 1, 13)
+        });
+        let def = ((arg_x, arg_y), res).chain(|((n_x, n_y), (_, n_r))| {
+            Definition {
+                names: vec![path!("mul")],
+                params: Some(vec![*n_x, *n_y]),
+                implementations: vec![*n_r],
+                path: path!(TEST_FN),
+            }
+            .at(TEST_FN, 1, 1)
+        });
+        assert_eq_err(def.run(&storage).map(|res| res.1), root)
     }
 
     #[test]
-    fn entity_parse_strings_with_operators_and_trailing_values_in_let() -> Test {
-        assert_str_eq!(
-            dbg_parse_entities("x()= !\"hello world\";\n7")?,
-            "\
-Entity 0:
- - HasValue('hello world')
- - InstancesAt(test.tk:1:7)
-Entity 1:
- - DefinedAt(None)
- - SymbolRef { name: [!], context: [test.tk, x], definition: None }
- - InstancesAt(test.tk:1:6)
-Entity 2:
- - Call { inner: Entity(1, Generation(1)), args: [Entity(0, Generation(1))] }
- - InstancesAt(test.tk:1:6)
-Entity 3:
- - Definition { names: [[x]], params: Some([]), implementations: [Entity(2, Generation(1))], path: [test.tk] }
- - InstancesAt(test.tk:1:1)
-Entity 4:
- - HasValue(7)
- - InstancesAt(test.tk:2:1)
-Entity 5:
- - DefinedAt(None)
- - SymbolRef { name: [;], context: [test.tk], definition: None }
- - InstancesAt(test.tk:1:20)
-Entity 6:
- - Call { inner: Entity(5, Generation(1)), args: [Entity(3, Generation(1)), Entity(4, Generation(1))] }
- - InstancesAt(test.tk:1:20)"
-        );
-        Ok(())
+    fn parse_strings_with_operators_and_trailing_values_in_let() -> Test {
+        let (root, storage) = parse_entities("x()= !\"hello world\";\n7")?;
+        let node_hello = HasValue::new(Prim::Str("hello world".to_string())).at(TEST_FN, 1, 7);
+        let node_not = SymbolRef::new(path!("!"), path!(TEST_FN, "x")).at(TEST_FN, 1, 6);
+        let x_impl = (node_hello, node_not).chain(|(n_h, n_n)| {
+            Call {
+                inner: *n_n,
+                args: vec![*n_h],
+            }
+            .at(TEST_FN, 1, 6)
+        });
+        let x_def = x_impl.chain(|(_n_h, n_i)| {
+            Definition {
+                names: vec![path!("x")],
+                params: Some(vec![]),
+                implementations: vec![*n_i],
+                path: path!(TEST_FN),
+            }
+            .at(TEST_FN, 1, 1)
+        });
+        let node_7 = HasValue::new(Prim::I32(7)).at(TEST_FN, 2, 1);
+        let node_semi = SymbolRef::new(path!(";"), path!(TEST_FN)).at(TEST_FN, 1, 20);
+        assert_eq_err(
+            ((x_def, node_semi), node_7)
+                .chain(|(((_, n_d), n_s), n_7)| {
+                    Call {
+                        inner: *n_s,
+                        args: vec![*n_d, *n_7],
+                    }
+                    .at(TEST_FN, 1, 20)
+                })
+                .run(&storage)
+                .map(|res| res.1),
+            root,
+        )
     }
 }

--- a/src/passes/parser.rs
+++ b/src/passes/parser.rs
@@ -796,9 +796,7 @@ pub mod tests {
                 ),
                 node_4,
             )
-                .with(|(((_, n_6), n_pls), n_4)| {
-                    Call::new(*n_pls, &[*n_6, *n_4]).at(TEST_FN, 1, 4)
-                })
+                .with(|(((_, n_6), n_pls), n_4)| Call::new(*n_pls, &[*n_6, *n_4]).at(TEST_FN, 1, 4))
                 .run(&storage)
                 .map(|res| res.1),
             root,
@@ -816,13 +814,10 @@ pub mod tests {
         assert_eq_err(
             (
                 (node_3, node_mul),
-                ((node_2, node_pls), node_4).with(|((n_2, n_pls), n_4)| {
-                    Call::new(*n_pls, &[*n_2, *n_4]).at(TEST_FN, 1, 5)
-                }),
+                ((node_2, node_pls), node_4)
+                    .with(|((n_2, n_pls), n_4)| Call::new(*n_pls, &[*n_2, *n_4]).at(TEST_FN, 1, 5)),
             )
-                .with(|((n_3, n_mul), (_, n_6))| {
-                    Call::new(*n_mul, &[*n_3, *n_6]).at(TEST_FN, 1, 2)
-                })
+                .with(|((n_3, n_mul), (_, n_6))| Call::new(*n_mul, &[*n_3, *n_6]).at(TEST_FN, 1, 2))
                 .run(&storage)
                 .map(|res| res.1),
             root,

--- a/src/passes/stack_interpreter.rs
+++ b/src/passes/stack_interpreter.rs
@@ -116,10 +116,7 @@ mod tests {
     use crate::primitives::{boolean, int32};
     use log::debug;
 
-    use crate::init_for_test;
-
     fn get_db() -> DBStorage {
-        init_for_test();
         DBStorage::default()
     }
 

--- a/src/passes/symbol_table_builder.rs
+++ b/src/passes/symbol_table_builder.rs
@@ -23,7 +23,7 @@ pub struct State {
 
 impl Visitor<State, Node, Root, Path> for SymbolTableBuilder {
     fn visit_root(&mut self, storage: &mut DBStorage, module: &Path) -> Result<Root, TError> {
-        let expr = &storage.parse_file(module)?;
+        let (expr, entity) = &storage.parse_file(module)?;
         info!("Building symbol table... {}", path_to_string(module));
 
         let mut table = Table::default();
@@ -52,6 +52,7 @@ impl Visitor<State, Node, Root, Path> for SymbolTableBuilder {
         debug!("table: {:?}", state.table);
         Ok(Root {
             ast: self.visit(storage, &mut state, expr)?,
+            entity: *entity,
             table: state.table,
         })
     }

--- a/src/passes/to_cpp.rs
+++ b/src/passes/to_cpp.rs
@@ -247,7 +247,7 @@ fn code_to_text(includes: &HashSet<String>, functions: &Vec<Code>) -> String {
     // TODO(cypher1): Use a writer.
     let mut code = "".to_string();
     // #includes
-    let mut includes: Vec<&String> = includes.into_iter().collect();
+    let mut includes: Vec<&String> = includes.iter().collect();
     includes.sort();
     for inc in includes {
         if inc.as_str() != "" {
@@ -282,13 +282,13 @@ impl<'a> System<'a> for CodeGeneratorSystem {
     type SystemData = ReadStorage<'a, SymbolRef>;
 
     fn run(&mut self, mut symbols: Self::SystemData) {
-        let mut code_for_entity: HashMap<Entity, Code> = HashMap::new();
+        let code_for_entity: HashMap<Entity, Code> = HashMap::new();
         // dbg!(&self.path_to_entity);
-        for symbol in (&mut symbols).join() {
+        for _symbol in (&mut symbols).join() {
             // code_for_entity.insert(, Code::);
         }
         // Work from the entry down
-        let mut includes = HashSet::new();
+        let includes = HashSet::new();
         let mut functions = Vec::new();
 
         if false {
@@ -366,7 +366,7 @@ impl Visitor<State, Code, Out, Path> for CodeGenerator {
             code,
             self.flags.clone(),
             (
-                code_generator.result.unwrap_or("".to_string()),
+                code_generator.result.unwrap_or_else(||"".to_string()),
                 code_generator.flags,
             ),
         ))

--- a/src/passes/to_cpp.rs
+++ b/src/passes/to_cpp.rs
@@ -239,10 +239,10 @@ struct CodeGeneratorSystem {
 impl<'a> System<'a> for CodeGeneratorSystem {
     type SystemData = ReadStorage<'a, SymbolRef>;
 
-    fn run(&mut self, mut symbols: Self::SystemData) {
+    fn run(&mut self, symbols: Self::SystemData) {
         let entity_to_code: HashMap<Entity, Code> = HashMap::new();
         // dbg!(&self.path_to_entity);
-        for _symbol in (&mut symbols).join() {
+        for _symbol in (&symbols).join() {
             // code_for_entity.insert(, Code::);
         }
         // Work from the entry down

--- a/src/passes/to_cpp.rs
+++ b/src/passes/to_cpp.rs
@@ -4,6 +4,7 @@ use crate::ast::{
 };
 use crate::components::SymbolRef;
 use crate::cpp_ast::Code;
+use crate::database::CompilationResult;
 use crate::database::DBStorage;
 use crate::errors::TError;
 use crate::primitives::{Prim, Val};
@@ -144,7 +145,7 @@ fn pretty_print_block(
 
 type Res = Result<Code, TError>;
 type State = Table;
-type Out = (String, HashSet<String>, (String, HashSet<String>));
+type Out = (CompilationResult, CompilationResult);
 
 fn build_call1(before: &str, inner: Code, entity_to_code: &HashMap<Entity, Code>) -> Code {
     inner.with_expr(
@@ -177,7 +178,7 @@ fn build_call2(
 
 fn code_to_text(
     includes: &HashSet<String>,
-    functions: &Vec<Code>,
+    functions: &[Code],
     entity_to_code: &HashMap<Entity, Code>,
 ) -> Result<String, TError> {
     // TODO(cypher1): Use a writer.
@@ -317,8 +318,7 @@ impl Visitor<State, Code, Out, Path> for CodeGenerator {
         // TODO(cypher1): Use a writer.
         let code = code_to_text(&self.includes, &self.functions, &self.entity_to_code)?;
         Ok((
-            code,
-            self.flags.clone(),
+            (code, self.flags.clone()),
             (
                 code_generator.result.unwrap_or_else(|| "".to_string()),
                 code_generator.flags,

--- a/src/passes/type_checker.rs
+++ b/src/passes/type_checker.rs
@@ -2,9 +2,7 @@ use crate::ast::{
     Node,
     Node::{AbsNode, ApplyNode, BinOpNode, LetNode, SymNode, UnOpNode, ValNode},
 };
-use crate::components::{
-    Call, DefinedAt, Definition, HasType, HasValue, Sequence, SymbolRef, Untyped,
-};
+use crate::components::{Call, Definition, HasType, HasValue, Sequence, SymbolRef, Untyped};
 use crate::database::DBStorage;
 use crate::errors::TError;
 use crate::passes::ast_interpreter::Interpreter;
@@ -25,7 +23,6 @@ impl<'a> System<'a> for TypeCheckerSystem {
     #[allow(clippy::type_complexity)]
     type SystemData = (
         ReadStorage<'a, Call>,
-        ReadStorage<'a, DefinedAt>,
         ReadStorage<'a, Definition>,
         WriteStorage<'a, HasType>,
         ReadStorage<'a, HasValue>,
@@ -36,11 +33,10 @@ impl<'a> System<'a> for TypeCheckerSystem {
 
     fn run(
         &mut self,
-        (calls, defined_at, definition, mut has_type, has_value, sequence, symbol_ref, mut untyped): Self::SystemData,
+        (calls, definition, mut has_type, has_value, sequence, symbol_ref, mut untyped): Self::SystemData,
     ) {
         for _ in (
             &calls,
-            &defined_at,
             &definition,
             &mut has_type,
             &has_value,
@@ -277,7 +273,7 @@ mod tests {
         let prog_filename = "test/prog.tk";
         let prog_module = storage.module_name(prog_filename);
 
-        let prog = storage.parse_str(&prog_module, prog_str)?;
+        let (prog, _entity) = storage.parse_str(&prog_module, prog_str)?;
 
         let env = Variable("test_program".to_string()); // TODO: Track the type env
         let prog_ty = infer(&mut storage, &prog, &env)?;

--- a/src/pretty_assertions.rs
+++ b/src/pretty_assertions.rs
@@ -1,3 +1,5 @@
+use crate::errors::TError;
+
 // Wrapper around string slice that makes debug output `{:?}` to print string same way as `{}`.
 // Used in different `assert*!` macros in combination with `pretty_assertions` crate to make
 // test failures to show nice diffs.
@@ -24,4 +26,27 @@ macro_rules! assert_str_eq {
             crate::pretty_assertions::MultiPretty($right.to_string())
         );
     };
+}
+
+pub fn assert_no_err<T: std::fmt::Debug, E: std::fmt::Display>(
+    res: Result<T, E>,
+) -> Result<T, TError>
+where
+    TError: From<E>,
+{
+    Ok(res.map_err(|err| {
+        eprintln!("{0}", &err);
+        err
+    })?)
+}
+
+pub fn assert_eq_err<T: PartialEq + std::fmt::Debug, E: std::fmt::Display>(
+    res: Result<T, E>,
+    rhs: T,
+) -> Result<(), TError>
+where
+    TError: From<E>,
+{
+    assert_eq!(assert_no_err(res)?, rhs);
+    Ok(())
 }

--- a/tests/goldens/_examples_higher_order.cc
+++ b/tests/goldens/_examples_higher_order.cc
@@ -1,0 +1,25 @@
+#include <iostream>
+#include <string>
+#include <sstream>
+namespace std{
+template <typename T>
+string to_string(const T& t){
+  stringstream out;
+  out << t;
+  return out.str();
+}
+string to_string(const bool& t){
+  return t ? "true" : "false";
+}
+}
+
+int main(int argc, char* argv[]) {
+  const auto _examples_higher_order_apply = [&](
+    const auto _examples_higher_order_apply_x,
+    const auto _examples_higher_order_apply_f
+  ) {
+    return _examples_higher_order_apply_f(_examples_higher_order_apply_f(_examples_higher_order_apply_x));
+  };
+  std::cout << ((std::to_string((std::to_string((std::to_string(_examples_higher_order_apply(3, [&](  const auto _examples_higher_order___it___f_y) {  return (_examples_higher_order___it___f_y*2);}))+std::to_string("  ")))+std::to_string(_examples_higher_order_apply(1, [&](  const auto _examples_higher_order___it___f_y) {  return !(_examples_higher_order___it___f_y);}))))+std::to_string("\n")));
+  return 0;
+}

--- a/tests/goldens/counter_examples_shadowing.cc
+++ b/tests/goldens/counter_examples_shadowing.cc
@@ -1,0 +1,7 @@
+int main(int argc, char* argv[]);
+
+int main(int argc, char* argv[]) {
+  const auto counter_examples_shadowing_x = 3;
+  const auto counter_examples_shadowing_x = (counter_examples_shadowing_x+2);
+  return counter_examples_shadowing_x;
+}

--- a/tests/goldens/examples_1_plus_2.cc
+++ b/tests/goldens/examples_1_plus_2.cc
@@ -1,3 +1,4 @@
+int main(int argc, char* argv[]);
 
 int main(int argc, char* argv[]) {
   return (1+2);

--- a/tests/goldens/examples_arguments.cc
+++ b/tests/goldens/examples_arguments.cc
@@ -1,3 +1,4 @@
+int main(int argc, char* argv[]);
 
 int main(int argc, char* argv[]) {
   const auto examples_arguments_x = [&](

--- a/tests/goldens/examples_code_reuse.cc
+++ b/tests/goldens/examples_code_reuse.cc
@@ -1,3 +1,4 @@
+int main(int argc, char* argv[]);
 
 int main(int argc, char* argv[]) {
   const auto examples_code_reuse_add = [&](

--- a/tests/goldens/examples_comment.cc
+++ b/tests/goldens/examples_comment.cc
@@ -1,3 +1,4 @@
+int main(int argc, char* argv[]);
 
 int main(int argc, char* argv[]) {
   return (3*4);

--- a/tests/goldens/examples_div.cc
+++ b/tests/goldens/examples_div.cc
@@ -1,3 +1,4 @@
+int main(int argc, char* argv[]);
 
 int main(int argc, char* argv[]) {
   return (20/4);

--- a/tests/goldens/examples_empty_def_args.cc
+++ b/tests/goldens/examples_empty_def_args.cc
@@ -1,3 +1,4 @@
+int main(int argc, char* argv[]);
 
 int main(int argc, char* argv[]) {
   const auto examples_empty_def_args_x = [&]() {

--- a/tests/goldens/examples_error_printing.cc
+++ b/tests/goldens/examples_error_printing.cc
@@ -1,0 +1,8 @@
+#include <iostream>
+int main(int argc, char* argv[]);
+
+int main(int argc, char* argv[]) {
+  std::cerr << ("This is an error!\n");
+  std::cout << ("This is a message!\n");
+  return 0;
+}

--- a/tests/goldens/examples_hello_name.cc
+++ b/tests/goldens/examples_hello_name.cc
@@ -12,6 +12,7 @@ string to_string(const bool& t){
   return t ? "true" : "false";
 }
 }
+int main(int argc, char* argv[]);
 
 int main(int argc, char* argv[]) {
   const auto examples_hello_name_name = ([&argv](const int x){return argv[x];})(1);

--- a/tests/goldens/examples_higher_order.cc
+++ b/tests/goldens/examples_higher_order.cc
@@ -12,6 +12,7 @@ string to_string(const bool& t){
   return t ? "true" : "false";
 }
 }
+int main(int argc, char* argv[]);
 
 int main(int argc, char* argv[]) {
   const auto examples_higher_order_apply = [&](

--- a/tests/goldens/examples_ignored_let.cc
+++ b/tests/goldens/examples_ignored_let.cc
@@ -1,3 +1,4 @@
+int main(int argc, char* argv[]);
 
 int main(int argc, char* argv[]) {
   return 1;

--- a/tests/goldens/examples_lambda.cc
+++ b/tests/goldens/examples_lambda.cc
@@ -1,3 +1,4 @@
+int main(int argc, char* argv[]);
 
 int main(int argc, char* argv[]) {
   return (700+7);

--- a/tests/goldens/examples_multi_comment.cc
+++ b/tests/goldens/examples_multi_comment.cc
@@ -1,3 +1,4 @@
+int main(int argc, char* argv[]);
 
 int main(int argc, char* argv[]) {
   return (3*3);

--- a/tests/goldens/examples_multi_comment_nested.cc
+++ b/tests/goldens/examples_multi_comment_nested.cc
@@ -1,3 +1,4 @@
+int main(int argc, char* argv[]);
 
 int main(int argc, char* argv[]) {
   return ((3*2)*5);

--- a/tests/goldens/examples_mutual_recursion.cc
+++ b/tests/goldens/examples_mutual_recursion.cc
@@ -1,0 +1,16 @@
+
+int main(int argc, char* argv[]) {
+  const auto examples_mutual_recursion_is_even = [&](
+    const auto examples_mutual_recursion_is_even_x
+  ) {
+    if((examples_mutual_recursion_is_even_x==0)) 1 else 
+    throw 101;
+  };
+  const auto examples_mutual_recursion_is_odd = [&](
+    const auto examples_mutual_recursion_is_odd_y
+  ) {
+    if((examples_mutual_recursion_is_odd_y==0)) 0 else 
+    throw 101;
+  };
+  return examples_mutual_recursion_is_even(18);
+}

--- a/tests/goldens/examples_neg.cc
+++ b/tests/goldens/examples_neg.cc
@@ -1,3 +1,4 @@
+int main(int argc, char* argv[]);
 
 int main(int argc, char* argv[]) {
   return -(3);

--- a/tests/goldens/examples_nested.cc
+++ b/tests/goldens/examples_nested.cc
@@ -1,3 +1,4 @@
+int main(int argc, char* argv[]);
 
 int main(int argc, char* argv[]) {
   const auto examples_nested_x = ([&]() {

--- a/tests/goldens/examples_nested_as_function.cc
+++ b/tests/goldens/examples_nested_as_function.cc
@@ -1,3 +1,4 @@
+int main(int argc, char* argv[]);
 
 int main(int argc, char* argv[]) {
   const auto examples_nested_as_function_x = [&]() {

--- a/tests/goldens/examples_nested_explicit.cc
+++ b/tests/goldens/examples_nested_explicit.cc
@@ -1,3 +1,4 @@
+int main(int argc, char* argv[]);
 
 int main(int argc, char* argv[]) {
   const auto examples_nested_explicit_x = ([&]() {

--- a/tests/goldens/examples_non_overlapping_anons.cc
+++ b/tests/goldens/examples_non_overlapping_anons.cc
@@ -1,3 +1,4 @@
+int main(int argc, char* argv[]);
 
 int main(int argc, char* argv[]) {
   const auto examples_non_overlapping_anons_x = [&](

--- a/tests/goldens/examples_not.cc
+++ b/tests/goldens/examples_not.cc
@@ -1,3 +1,4 @@
+int main(int argc, char* argv[]);
 
 int main(int argc, char* argv[]) {
   return !(1);

--- a/tests/goldens/examples_optional_semis.cc
+++ b/tests/goldens/examples_optional_semis.cc
@@ -1,3 +1,4 @@
+int main(int argc, char* argv[]);
 
 int main(int argc, char* argv[]) {
   const auto examples_optional_semis_x = 3;

--- a/tests/goldens/examples_order_of_ops.cc
+++ b/tests/goldens/examples_order_of_ops.cc
@@ -1,3 +1,4 @@
+int main(int argc, char* argv[]);
 
 int main(int argc, char* argv[]) {
   return (1+(2*3));

--- a/tests/goldens/examples_paren.cc
+++ b/tests/goldens/examples_paren.cc
@@ -1,3 +1,4 @@
+int main(int argc, char* argv[]);
 
 int main(int argc, char* argv[]) {
   return ((1+2)*3);

--- a/tests/goldens/examples_parse_i32.cc
+++ b/tests/goldens/examples_parse_i32.cc
@@ -13,6 +13,7 @@ string to_string(const bool& t){
   return t ? "true" : "false";
 }
 }
+int main(int argc, char* argv[]);
 
 int main(int argc, char* argv[]) {
   std::cout << ((std::to_string((std::stoi(([&argv](const int x){return argv[x];})(1))+1))+std::to_string("\n")));

--- a/tests/goldens/examples_pow.cc
+++ b/tests/goldens/examples_pow.cc
@@ -1,4 +1,5 @@
 #include <cmath>
+int main(int argc, char* argv[]);
 
 int main(int argc, char* argv[]) {
   return (3*pow(2, 2));

--- a/tests/goldens/examples_pow_twice.cc
+++ b/tests/goldens/examples_pow_twice.cc
@@ -1,4 +1,5 @@
 #include <cmath>
+int main(int argc, char* argv[]);
 
 int main(int argc, char* argv[]) {
   return pow(2, pow(3, 2));

--- a/tests/goldens/examples_printing.cc
+++ b/tests/goldens/examples_printing.cc
@@ -12,6 +12,7 @@ string to_string(const bool& t){
   return t ? "true" : "false";
 }
 }
+int main(int argc, char* argv[]);
 
 int main(int argc, char* argv[]) {
   std::cout << ((std::to_string(((3*3)*2))+std::to_string("\n")));

--- a/tests/goldens/examples_simple.cc
+++ b/tests/goldens/examples_simple.cc
@@ -1,3 +1,4 @@
+int main(int argc, char* argv[]);
 
 int main(int argc, char* argv[]) {
   return (((3*2)+(5*2))+1);

--- a/tests/goldens/examples_simple_call.cc
+++ b/tests/goldens/examples_simple_call.cc
@@ -1,3 +1,4 @@
+int main(int argc, char* argv[]);
 
 int main(int argc, char* argv[]) {
   const auto examples_simple_call_x = [&](

--- a/tests/goldens/examples_sub.cc
+++ b/tests/goldens/examples_sub.cc
@@ -1,3 +1,4 @@
+int main(int argc, char* argv[]);
 
 int main(int argc, char* argv[]) {
   return ((17-5)-3);

--- a/tests/goldens/examples_three_vars.cc
+++ b/tests/goldens/examples_three_vars.cc
@@ -1,3 +1,4 @@
+int main(int argc, char* argv[]);
 
 int main(int argc, char* argv[]) {
   const auto examples_three_vars_x = 2;

--- a/tests/goldens/examples_tmp.cc
+++ b/tests/goldens/examples_tmp.cc
@@ -1,3 +1,4 @@
+int main(int argc, char* argv[]);
 
 int main(int argc, char* argv[]) {
   return (((2*3)*(9-3))/3);

--- a/tests/goldens/examples_x_plus_1.cc
+++ b/tests/goldens/examples_x_plus_1.cc
@@ -1,3 +1,4 @@
+int main(int argc, char* argv[]);
 
 int main(int argc, char* argv[]) {
   const auto examples_x_plus_1_x = 3;


### PR DESCRIPTION
- Store 'externs' in DBStorage with other definitions
- Update compiler pass tests to use Matcher (where the pass is updated to use entities)
- Disable compiler pass tests where the pass is not updated to use entities